### PR TITLE
Docker jdk 17 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk
+FROM openjdk:17-jdk
 # JAR_FILE 변수에 값을 저장
 ARG JAR_FILE=./build/libs/server-0.0.1-SNAPSHOT.jar
 # 변수에 저장된 것을 컨테이너 실행시 이름을 app.jar파일로 변경하여 컨테이너에 저장


### PR DESCRIPTION
## 작업 내용
Run 단계에서 jdk 버전 관련 충돌이 발생하여 확인해보기 jdk 문제 에러가 발생하여 도커파일에서 jdk 11에서 17로 변경하였습니다.
`has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0`