### PR TITLE
[hotfix] #13 Dev 서버 배포 시, application-dev 프로퍼티 주입 명령어 추가

### DIFF
--- a/.github/workflows/cd_dev.yml
+++ b/.github/workflows/cd_dev.yml
@@ -1,8 +1,8 @@
-name: CD for Prod
+name: CD for Dev
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "develop" ]
 
 permissions: write-all
 
@@ -79,5 +79,5 @@ jobs:
             docker stop dev
             docker rm dev
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY}}
-            sudo docker run -d --name dev -v /var/log/app:/var/log/app -v /etc/localtime:/etc/localtime:ro -e TZ=Asia/Seoul -e ENVIRONMENT_VALUE=-Dspring.profiles.active=prod -p 8085:8080 ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY}}:latest
+            sudo docker run -d --name dev -v /var/log/app:/var/log/app -v /etc/localtime:/etc/localtime:ro -e TZ=Asia/Seoul -e ENVIRONMENT_VALUE=-Dspring.profiles.active=dev -p 8085:8080 ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY}}:latest
             docker rmi -f $(docker images -f "dangling=true" -q)


### PR DESCRIPTION
## 작업 내용
기존 cd_prod 파일 내에 prod 서버로 배포되도록 타겟 브랜치 develop -> main 으로 변경 및 프로퍼티 주입 명령어 추가

## 관련 이슈
#13

## 작업 확인 방법

## 추가 정보 (선택 사항)
