### PR TITLE
[Feature/user withdrawal] 마이페이지-회원탈퇴 API

### DIFF
--- a/src/main/java/everymeal/server/user/controller/UserController.java
+++ b/src/main/java/everymeal/server/user/controller/UserController.java
@@ -8,6 +8,7 @@ import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
 import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
+import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
@@ -26,6 +27,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -143,6 +145,26 @@ public class UserController {
     public ApplicationResponse<UserProfileRes> getUserProfile(
             @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser) {
         return ApplicationResponse.ok(userService.getUserProfile(authenticatedUser));
+    }
+
+    @Auth(require = true)
+    @PutMapping("/profile")
+    @SecurityRequirement(name = "jwt-user-auth")
+    @Operation(summary = "인증된 사용자의 프로필 정보 수정", description = "인증된 사용자의 프로필 정보를 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(
+                responseCode = "409",
+                description =
+                        """
+                    (U0005)이미 등록된 닉네임입니다.<br>
+                    """,
+                content = @Content(schema = @Schema())),
+    })
+    public ApplicationResponse<Boolean> updateUserProfile(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser,
+            @RequestBody UserProfileUpdateReq userProfileUpdateReq) {
+        return ApplicationResponse.ok(
+                userService.updateUserProfile(authenticatedUser, userProfileUpdateReq));
     }
 
     private ResponseEntity<ApplicationResponse<UserLoginRes>> setRefreshToken(

--- a/src/main/java/everymeal/server/user/controller/UserController.java
+++ b/src/main/java/everymeal/server/user/controller/UserController.java
@@ -151,15 +151,12 @@ public class UserController {
     @PutMapping("/profile")
     @SecurityRequirement(name = "jwt-user-auth")
     @Operation(summary = "인증된 사용자의 프로필 정보 수정", description = "인증된 사용자의 프로필 정보를 수정합니다.")
-    @ApiResponses({
-        @ApiResponse(
-                responseCode = "409",
-                description =
-                        """
+    @ApiResponse(
+            responseCode = "409",
+            description = """
                     (U0005)이미 등록된 닉네임입니다.<br>
                     """,
-                content = @Content(schema = @Schema())),
-    })
+            content = @Content(schema = @Schema()))
     public ApplicationResponse<Boolean> updateUserProfile(
             @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser,
             @RequestBody UserProfileUpdateReq userProfileUpdateReq) {

--- a/src/main/java/everymeal/server/user/controller/UserController.java
+++ b/src/main/java/everymeal/server/user/controller/UserController.java
@@ -9,6 +9,7 @@ import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
 import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
+import everymeal.server.user.controller.dto.request.WithdrawalReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
@@ -162,6 +163,22 @@ public class UserController {
             @RequestBody UserProfileUpdateReq userProfileUpdateReq) {
         return ApplicationResponse.ok(
                 userService.updateUserProfile(authenticatedUser, userProfileUpdateReq));
+    }
+
+    @Auth(require = true)
+    @PostMapping("/withdrawal")
+    @SecurityRequirement(name = "jwt-user-auth")
+    @Operation(summary = "회원탈퇴", description = "서비스 회원 탈퇴를 합니다.")
+    @ApiResponse(
+            responseCode = "404",
+            description = """
+                    (U0001)등록된 유저가 아닙니다.<br>
+                    """,
+            content = @Content(schema = @Schema()))
+    public ApplicationResponse<Boolean> withdrawal(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser,
+            @RequestBody WithdrawalReq withdrawalReq) {
+        return ApplicationResponse.ok(userService.withdrawal(authenticatedUser, withdrawalReq));
     }
 
     private ResponseEntity<ApplicationResponse<UserLoginRes>> setRefreshToken(

--- a/src/main/java/everymeal/server/user/controller/dto/request/UserProfileUpdateReq.java
+++ b/src/main/java/everymeal/server/user/controller/dto/request/UserProfileUpdateReq.java
@@ -1,0 +1,9 @@
+package everymeal.server.user.controller.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserProfileUpdateReq(
+        @Schema(description = "닉네임", example = "연유크림") String nickName,
+        @Schema(description = "프로필 이미지 key", example = "user/bc90af33-bc6a-4009-bfc8-2c3efe0b16bd")
+                String profileImageKey) {}

--- a/src/main/java/everymeal/server/user/controller/dto/request/WithdrawalReq.java
+++ b/src/main/java/everymeal/server/user/controller/dto/request/WithdrawalReq.java
@@ -1,0 +1,12 @@
+package everymeal.server.user.controller.dto.request;
+
+
+import everymeal.server.user.entity.WithdrawalReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawalReq(
+        @NotBlank @Schema(description = "탈퇴 사유를 입력해주세요.", example = "NOT_USE_USUALLY")
+                WithdrawalReason withdrawalReason,
+        @Schema(description = "사유가 '기타'일 경우, 추가 이유 입력해주세요.", example = "다른 서비스를 사용하게 되었다.")
+                String etcReason) {}

--- a/src/main/java/everymeal/server/user/controller/dto/request/WithdrawalReq.java
+++ b/src/main/java/everymeal/server/user/controller/dto/request/WithdrawalReq.java
@@ -6,7 +6,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record WithdrawalReq(
-        @NotBlank @Schema(description = "탈퇴 사유를 입력해주세요.", example = "NOT_USE_USUALLY")
+        @NotBlank
+                @Schema(
+                        description = "탈퇴 사유를 입력해주세요.",
+                        example = "NOT_USE_USUALLY",
+                        allowableValues = {
+                            "NOT_USE_USUALLY",
+                            "INCONVENIENT_IN_TERMS_OF_USABILITY",
+                            "ERRORS_OCCUR_FREQUENTLY",
+                            "MY_SCHOOL_HAS_CHANGED",
+                            "ETC"
+                        })
                 WithdrawalReason withdrawalReason,
         @Schema(description = "사유가 '기타'일 경우, 추가 이유 입력해주세요.", example = "다른 서비스를 사용하게 되었다.")
                 String etcReason) {}

--- a/src/main/java/everymeal/server/user/controller/dto/response/UserProfileRes.java
+++ b/src/main/java/everymeal/server/user/controller/dto/response/UserProfileRes.java
@@ -5,11 +5,11 @@ import java.util.Map;
 
 public record UserProfileRes(
         Long userId, String nickName, String profileImgUrl, String universityName) {
-    public static UserProfileRes of(Map<String, Object> user) {
+    public static UserProfileRes of(Map<String, Object> user, String profileImgUrl) {
         return new UserProfileRes(
                 (Long) user.get("userId"),
                 (String) user.get("nickName"),
-                (String) user.get("profileImgUrl"),
+                profileImgUrl,
                 (String) user.get("universityName"));
     }
 }

--- a/src/main/java/everymeal/server/user/entity/User.java
+++ b/src/main/java/everymeal/server/user/entity/User.java
@@ -65,4 +65,9 @@ public class User extends BaseEntity {
     public void setEmail(String email) {
         this.email = email;
     }
+
+    public void updateProfile(String nickname, String profileImgUrl) {
+        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
+    }
 }

--- a/src/main/java/everymeal/server/user/entity/User.java
+++ b/src/main/java/everymeal/server/user/entity/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;
@@ -53,6 +54,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     Set<ReviewMark> reviewMarks = new HashSet<>();
 
+    @OneToOne(mappedBy = "user")
+    private Withdrawal withdrawal;
+
     @Builder
     public User(String nickname, String email, String profileImgUrl, University university) {
         this.nickname = nickname;
@@ -69,5 +73,9 @@ public class User extends BaseEntity {
     public void updateProfile(String nickname, String profileImgUrl) {
         this.nickname = nickname;
         this.profileImgUrl = profileImgUrl;
+    }
+    /** 회원 탈퇴 */
+    public void setIsDeleted() {
+        this.isDeleted = Boolean.TRUE;
     }
 }

--- a/src/main/java/everymeal/server/user/entity/Withdrawal.java
+++ b/src/main/java/everymeal/server/user/entity/Withdrawal.java
@@ -25,7 +25,7 @@ public class Withdrawal extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private WithdrawalReason withdrawalReason;
 
-    @Column(nullable = true, length = 100)
+    @Column(nullable = true, columnDefinition = "TEXT")
     private String etcReason;
 
     @MapsId

--- a/src/main/java/everymeal/server/user/entity/Withdrawal.java
+++ b/src/main/java/everymeal/server/user/entity/Withdrawal.java
@@ -1,0 +1,42 @@
+package everymeal.server.user.entity;
+
+
+import everymeal.server.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Withdrawal extends BaseEntity {
+    @Id private Long userIdx;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private WithdrawalReason withdrawalReason;
+
+    @Column(nullable = true, length = 100)
+    private String etcReason;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "user_idx", referencedColumnName = "idx")
+    private User user;
+
+    @Builder
+    public Withdrawal(WithdrawalReason withdrawalReason, String etcReason, User user) {
+        this.withdrawalReason = withdrawalReason;
+        this.etcReason = etcReason;
+        this.user = user;
+    }
+}

--- a/src/main/java/everymeal/server/user/entity/WithdrawalReason.java
+++ b/src/main/java/everymeal/server/user/entity/WithdrawalReason.java
@@ -1,0 +1,17 @@
+package everymeal.server.user.entity;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WithdrawalReason {
+    NOT_USE_USUALLY("앱을 잘 쓰지 않아요"),
+    INCONVENIENT_IN_TERMS_OF_USABILITY("사용성이 불편해요"),
+    ERRORS_OCCUR_FREQUENTLY("오류가 자주 발생해요"),
+    MY_SCHOOL_HAS_CHANGED("학교가 바뀌었어요"),
+    ETC("기타");
+
+    public final String MESSAGE;
+}

--- a/src/main/java/everymeal/server/user/repository/WithdrawalRepository.java
+++ b/src/main/java/everymeal/server/user/repository/WithdrawalRepository.java
@@ -1,0 +1,7 @@
+package everymeal.server.user.repository;
+
+
+import everymeal.server.user.entity.Withdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawalRepository extends JpaRepository<Withdrawal, Long> {}

--- a/src/main/java/everymeal/server/user/service/UserService.java
+++ b/src/main/java/everymeal/server/user/service/UserService.java
@@ -5,6 +5,7 @@ import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
 import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
+import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
@@ -22,4 +23,7 @@ public interface UserService {
     Boolean checkUser(String email);
 
     UserProfileRes getUserProfile(AuthenticatedUser authenticatedUser);
+
+    Boolean updateUserProfile(
+            AuthenticatedUser authenticatedUser, UserProfileUpdateReq userProfileUpdateReq);
 }

--- a/src/main/java/everymeal/server/user/service/UserService.java
+++ b/src/main/java/everymeal/server/user/service/UserService.java
@@ -6,6 +6,7 @@ import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
 import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
+import everymeal.server.user.controller.dto.request.WithdrawalReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
@@ -26,4 +27,6 @@ public interface UserService {
 
     Boolean updateUserProfile(
             AuthenticatedUser authenticatedUser, UserProfileUpdateReq userProfileUpdateReq);
+
+    Boolean withdrawal(AuthenticatedUser authenticatedUser, WithdrawalReq request);
 }

--- a/src/main/java/everymeal/server/user/service/UserServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/UserServiceImpl.java
@@ -196,7 +196,7 @@ public class UserServiceImpl implements UserService {
                             .user(user)
                             .build();
         } else // 기타를 선택한 경우
-            withdrawal =
+        withdrawal =
                     Withdrawal.builder()
                             .withdrawalReason(request.withdrawalReason())
                             .etcReason(request.etcReason()) // 글자수 제한이 있는지 처리 X

--- a/src/main/java/everymeal/server/user/service/UserServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/UserServiceImpl.java
@@ -199,7 +199,7 @@ public class UserServiceImpl implements UserService {
         withdrawal =
                     Withdrawal.builder()
                             .withdrawalReason(request.withdrawalReason())
-                            .etcReason(request.etcReason()) // 글자수 제한이 있는지 처리 X
+                            .etcReason(request.etcReason())
                             .user(user)
                             .build();
         withdrawalRepository.save(withdrawal); // 탈퇴 관련 정보 저장

--- a/src/main/java/everymeal/server/user/service/UserServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/UserServiceImpl.java
@@ -13,12 +13,16 @@ import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
 import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
+import everymeal.server.user.controller.dto.request.WithdrawalReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
 import everymeal.server.user.entity.User;
+import everymeal.server.user.entity.Withdrawal;
+import everymeal.server.user.entity.WithdrawalReason;
 import everymeal.server.user.repository.UserMapper;
 import everymeal.server.user.repository.UserRepository;
+import everymeal.server.user.repository.WithdrawalRepository;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Map;
@@ -39,6 +43,7 @@ public class UserServiceImpl implements UserService {
     private final MailUtil mailUtil;
     private final S3Util s3Util;
     private final UserMapper userMapper;
+    private final WithdrawalRepository withdrawalRepository;
 
     @Override
     @Transactional
@@ -173,6 +178,32 @@ public class UserServiceImpl implements UserService {
             throw new ApplicationException(ExceptionList.NICKNAME_ALREADY_EXIST);
         }
         user.updateProfile(request.nickName(), request.profileImageKey());
+        return true;
+    }
+
+    @Override
+    @Transactional
+    public Boolean withdrawal(AuthenticatedUser authenticatedUser, WithdrawalReq request) {
+        User user =
+                userRepository
+                        .findById(authenticatedUser.getIdx())
+                        .orElseThrow(() -> new ApplicationException(ExceptionList.USER_NOT_FOUND));
+        Withdrawal withdrawal;
+        if (request.withdrawalReason() != WithdrawalReason.ETC) { // 기타를 제외한 경우
+            withdrawal =
+                    Withdrawal.builder()
+                            .withdrawalReason(request.withdrawalReason())
+                            .user(user)
+                            .build();
+        } else // 기타를 선택한 경우
+            withdrawal =
+                    Withdrawal.builder()
+                            .withdrawalReason(request.withdrawalReason())
+                            .etcReason(request.etcReason()) // 글자수 제한이 있는지 처리 X
+                            .user(user)
+                            .build();
+        withdrawalRepository.save(withdrawal); // 탈퇴 관련 정보 저장
+        user.setIsDeleted(); // 논리 삭제
         return true;
     }
 }

--- a/src/test/java/everymeal/server/user/controller/UserControllerTest.java
+++ b/src/test/java/everymeal/server/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -14,6 +15,7 @@ import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
 import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
+import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -130,6 +132,25 @@ class UserControllerTest extends ControllerTestSupport {
                 .willReturn(AuthenticatedUser.builder().idx(1L).build());
         // when-then
         mockMvc.perform(get("/api/v1/users/profile").contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("인증된 유저의 프로필 정보 수정")
+    @Test
+    void updateUserProfile() throws Exception {
+        // given
+        UserProfileUpdateReq request = new UserProfileUpdateReq("연유크림", "imageKey");
+
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
+
+        // when-then
+        mockMvc.perform(
+                        put("/api/v1/users/profile")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("OK"));

--- a/src/test/java/everymeal/server/user/controller/UserControllerTest.java
+++ b/src/test/java/everymeal/server/user/controller/UserControllerTest.java
@@ -16,7 +16,9 @@ import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
 import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
+import everymeal.server.user.controller.dto.request.WithdrawalReq;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
+import everymeal.server.user.entity.WithdrawalReason;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -149,6 +151,25 @@ class UserControllerTest extends ControllerTestSupport {
         // when-then
         mockMvc.perform(
                         put("/api/v1/users/profile")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("회원 탈퇴")
+    @Test
+    void withdrawal() throws Exception {
+        // given
+        WithdrawalReq request = new WithdrawalReq(WithdrawalReason.ERRORS_OCCUR_FREQUENTLY, "");
+
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
+
+        // when-then
+        mockMvc.perform(
+                        post("/api/v1/users/withdrawal")
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())


### PR DESCRIPTION
## 작업 내용
마이페이지-회원탈퇴 API 개발

## 관련 이슈
#66 

## 작업 확인 방법
swagger-ui를 통해 확인 가능

## 추가 정보 (선택 사항)

- 회원 탈퇴 테이블 PK 값을 User 테이블 PK로 지정하여 식별 관계로 구성했습니다. OneToOne이기도 하고, 탈퇴에 대한 정책이 명확하지 않아 `1명의 유저가 1번의 탈퇴 기록을 갖는다.`로 정의하고 구성했습니다.

- 회원 탈퇴 사유를 '기타'로 선택할 경우, 추가 사유를 작성하는 UI가 있습니다. 이 부분에서 글자수 제한 정책이 명확하지 않아 최대 100글자로만 정의하였습니다. 즉, 아무 글자를 입력하지 않아도 저장이 되도록 구현되어 있습니다. 

### 🙋🏻‍♀️ 질문

1. 회원이 탈퇴를 할 경우, 앱에서 팝업으로만 탈퇴를 명시하나요?

이 방법 외에 생각한 것은 이메일 주소를 알고 있고, 논리 삭제 방식이니 탈퇴 이후 사용자 이메일 주소로 탈퇴 사실을 한번더 통지하는 것을 생각했습니다. 

2. 논리 삭제 방식으로 탈퇴 상태를 구분하고 있는데, 탈퇴 유저가 로그인이나 회원가입을 시도했을 때의 정책은 어떻게 되는 건가요?

신규 유저로 볼 것인지 기존 데이터를 다시 제공할 것인지가 궁금합니다.