### PR TITLE
[Feature/store like get] 마이페이지-저장목록 조회 및 가게저장 API 개발

### DIFF
--- a/src/main/java/everymeal/server/global/exception/ExceptionList.java
+++ b/src/main/java/everymeal/server/global/exception/ExceptionList.java
@@ -24,7 +24,9 @@ public enum ExceptionList {
     TOKEN_NOT_VALID("T0001", HttpStatus.NOT_ACCEPTABLE, "해당 토큰은 유효하지 않습니다."),
     TOKEN_EXPIRATION("T0002", HttpStatus.FORBIDDEN, "토큰이 만료되었습니다."),
 
-    REVIEW_NOT_FOUND("R0001", HttpStatus.NOT_FOUND, "등록된 리뷰가 아닙니다."),
+    REVIEW_NOT_FOUND("RV0001", HttpStatus.NOT_FOUND, "등록된 리뷰가 아닙니다."),
+
+    STORE_NOT_FOUND("S0001", HttpStatus.NOT_FOUND, "등록된 가게가 아닙니다."),
     ;
 
     public final String CODE;

--- a/src/main/java/everymeal/server/store/controller/StoreController.java
+++ b/src/main/java/everymeal/server/store/controller/StoreController.java
@@ -11,11 +11,14 @@ import everymeal.server.global.dto.response.ApplicationResponse;
 import everymeal.server.global.util.authresolver.Auth;
 import everymeal.server.global.util.authresolver.AuthUser;
 import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
+import everymeal.server.store.controller.dto.response.LikedStoreGetRes;
 import everymeal.server.store.controller.dto.response.StoreGetRes;
 import everymeal.server.store.service.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -94,5 +98,60 @@ public class StoreController {
                         authenticatedUser == null ? null : authenticatedUser.getIdx(),
                         order,
                         grade));
+    }
+
+    @Auth(require = true)
+    @GetMapping("/likes")
+    @SecurityRequirement(name = "jwt-user-auth")
+    @Operation(summary = "인증된 사용자의 저장 목록 조회", description = "인증된 사용자의 저장 목록을 조회합니다.")
+    public ApplicationResponse<Page<LikedStoreGetRes>> getUserLikesStore(
+            @RequestParam(value = "campusIdx")
+                    @Schema(title = "캠퍼스 키 값", description = "캠퍼스 키 값", example = "1")
+                    Long campusIdx,
+            @RequestParam(value = "offset", defaultValue = "0")
+                    @Schema(title = "페이지 번호", example = "0", description = "페이지 번호는 0부터 시작합니다.")
+                    Integer offset,
+            @RequestParam(value = "limit", defaultValue = "10")
+                    @Schema(
+                            title = "Data 갯수",
+                            example = "10",
+                            description = "한 페이지에 보여지는 데이터 수 입니다.")
+                    Integer limit,
+            @RequestParam(value = "group", required = false, defaultValue = "all")
+                    @Schema(
+                            title = "그룹",
+                            description = "그룹",
+                            allowableValues = {
+                                "all",
+                                "etc",
+                                "recommend",
+                                "restaurant",
+                                "cafe",
+                                "bar"
+                            })
+                    String group,
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser) {
+        return ApplicationResponse.ok(
+                storeService.getUserLikesStore(
+                        campusIdx, PageRequest.of(offset, limit), group, authenticatedUser));
+    }
+
+    @Auth(require = true)
+    @PostMapping("/likes/{storeIdx}")
+    @SecurityRequirement(name = "jwt-user-auth")
+    @Operation(summary = "인증된 사용자의 가게 저장 및 저장해제", description = "가게를 저장 혹은 저장을 해제합니다.")
+    @ApiResponse(
+            responseCode = "404",
+            description = """
+      (U0001)유저를 찾을 수 없습니다.
+      (S0001)등록된 가게가 아닙니다.
+      """,
+            content = @Content(schema = @Schema()))
+    public ApplicationResponse<Boolean> likesStore(
+            @PathVariable(value = "storeIdx")
+                    @Schema(title = "가게 키 값", description = "가게 키 값", example = "386")
+                    Long storeIdx,
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser) {
+        return ApplicationResponse.ok(storeService.likesStore(storeIdx, authenticatedUser));
     }
 }

--- a/src/main/java/everymeal/server/store/controller/dto/response/LikedStoreGetRes.java
+++ b/src/main/java/everymeal/server/store/controller/dto/response/LikedStoreGetRes.java
@@ -1,0 +1,50 @@
+package everymeal.server.store.controller.dto.response;
+
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public record LikedStoreGetRes(
+        Long idx,
+        String name,
+        String address,
+        String phoneNumber,
+        String categoryDetail,
+        Integer distance,
+        Double grade,
+        Integer reviewCount,
+        Integer recommendedCount,
+        List<String> images,
+        Boolean isLiked,
+        Long userLikesCount) {
+    public static List<LikedStoreGetRes> of(List<Map<String, Object>> stores) {
+        return stores.stream()
+                .map(
+                        store -> {
+                            List<String> images = null;
+                            if (store.get("images") != null) {
+                                images = Arrays.asList(((String) store.get("images")).split(","));
+                            }
+                            boolean isLiked = false;
+                            Integer isLikedInt = (Integer) store.get("isLiked");
+                            if (isLikedInt == 1) {
+                                isLiked = true;
+                            }
+                            return new LikedStoreGetRes(
+                                    (Long) store.get("idx"),
+                                    (String) store.get("name"),
+                                    (String) store.get("address"),
+                                    (String) store.get("phoneNumber"),
+                                    (String) store.get("categoryDetail"),
+                                    (Integer) store.get("distance"),
+                                    (Double) store.get("grade"),
+                                    (Integer) store.get("reviewCount"),
+                                    (Integer) store.get("recommendedCount"),
+                                    images,
+                                    isLiked,
+                                    (Long) store.get("userLikesCount"));
+                        })
+                .toList();
+    }
+}

--- a/src/main/java/everymeal/server/store/repository/StoreMapper.java
+++ b/src/main/java/everymeal/server/store/repository/StoreMapper.java
@@ -28,4 +28,22 @@ public interface StoreMapper {
             @Param("userIdx") Long userIdx,
             @Param("order") String order,
             @Param("grade") Integer grade);
+
+    List<Map<String, Object>> getUserLikesStore(
+            @Param("universityIdx") Long universityIdx,
+            @Param("limit") Integer limit,
+            @Param("offset") Long offset,
+            @Param("group") String group,
+            @Param("userIdx") Long userIdx,
+            @Param("order") String order,
+            @Param("grade") Integer grade);
+
+    Long getUserLikesStoreCount(
+            @Param("universityIdx") Long universityIdx,
+            @Param("limit") Integer limit,
+            @Param("offset") Long offset,
+            @Param("group") String group,
+            @Param("userIdx") Long userIdx,
+            @Param("order") String order,
+            @Param("grade") Integer grade);
 }

--- a/src/main/java/everymeal/server/store/service/StoreService.java
+++ b/src/main/java/everymeal/server/store/service/StoreService.java
@@ -1,6 +1,8 @@
 package everymeal.server.store.service;
 
 
+import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
+import everymeal.server.store.controller.dto.response.LikedStoreGetRes;
 import everymeal.server.store.controller.dto.response.StoreGetRes;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,4 +11,9 @@ public interface StoreService {
 
     Page<StoreGetRes> getStores(
             Long campusIdx, Pageable of, String group, Long userIdx, String order, Integer grade);
+
+    Page<LikedStoreGetRes> getUserLikesStore(
+            Long campusIdx, Pageable of, String group, AuthenticatedUser authenticatedUser);
+
+    Boolean likesStore(Long storeIdx, AuthenticatedUser authenticatedUser);
 }

--- a/src/main/java/everymeal/server/store/service/StoreServiceImpl.java
+++ b/src/main/java/everymeal/server/store/service/StoreServiceImpl.java
@@ -1,21 +1,37 @@
 package everymeal.server.store.service;
 
+import static everymeal.server.global.exception.ExceptionList.STORE_NOT_FOUND;
 
+import everymeal.server.global.exception.ApplicationException;
+import everymeal.server.global.exception.ExceptionList;
+import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
+import everymeal.server.store.controller.dto.response.LikedStoreGetRes;
 import everymeal.server.store.controller.dto.response.StoreGetRes;
+import everymeal.server.store.entity.Store;
 import everymeal.server.store.repository.StoreMapper;
+import everymeal.server.store.repository.StoreRepository;
+import everymeal.server.user.entity.Like;
+import everymeal.server.user.entity.User;
+import everymeal.server.user.repository.LikeRepository;
+import everymeal.server.user.repository.UserRepository;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class StoreServiceImpl implements StoreService {
 
     private final StoreMapper storeMapper;
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
 
     @Override
     public Page<StoreGetRes> getStores(
@@ -45,5 +61,51 @@ public class StoreServiceImpl implements StoreService {
                         order,
                         grade);
         return new PageImpl<>(result, pageable, count);
+    }
+
+    @Override
+    public Page<LikedStoreGetRes> getUserLikesStore(
+            Long campusIdx, Pageable pageable, String group, AuthenticatedUser authenticatedUser) {
+        List<Map<String, Object>> stores =
+                storeMapper.getUserLikesStore(
+                        campusIdx,
+                        pageable.getPageSize(),
+                        pageable.getOffset(),
+                        group,
+                        authenticatedUser.getIdx(),
+                        "name",
+                        null);
+        List<LikedStoreGetRes> result = LikedStoreGetRes.of(stores);
+        Long count =
+                storeMapper.getUserLikesStoreCount(
+                        campusIdx,
+                        pageable.getPageSize(),
+                        pageable.getOffset(),
+                        group,
+                        authenticatedUser.getIdx(),
+                        "name",
+                        null);
+        return new PageImpl<>(result, pageable, count);
+    }
+
+    @Override
+    @Transactional
+    public Boolean likesStore(Long storeIdx, AuthenticatedUser authenticatedUser) {
+        User user =
+                userRepository
+                        .findById(authenticatedUser.getIdx())
+                        .orElseThrow(() -> new ApplicationException(ExceptionList.USER_NOT_FOUND));
+        Store store =
+                storeRepository
+                        .findById(storeIdx)
+                        .orElseThrow(() -> new ApplicationException(STORE_NOT_FOUND));
+        Optional<Like> isLikedStore = likeRepository.findByUserAndStore(user, store);
+        if (isLikedStore.isPresent()) {
+            likeRepository.delete(isLikedStore.get());
+        } else {
+            Like like = Like.builder().store(store).user(user).build();
+            likeRepository.save(like);
+        }
+        return true;
     }
 }

--- a/src/main/java/everymeal/server/store/service/StoreServiceImpl.java
+++ b/src/main/java/everymeal/server/store/service/StoreServiceImpl.java
@@ -102,10 +102,11 @@ public class StoreServiceImpl implements StoreService {
         Optional<Like> isLikedStore = likeRepository.findByUserAndStore(user, store);
         if (isLikedStore.isPresent()) {
             likeRepository.delete(isLikedStore.get());
+            return false;
         } else {
             Like like = Like.builder().store(store).user(user).build();
             likeRepository.save(like);
+            return true;
         }
-        return true;
     }
 }

--- a/src/main/java/everymeal/server/user/controller/UserController.java
+++ b/src/main/java/everymeal/server/user/controller/UserController.java
@@ -8,6 +8,7 @@ import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
 import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
+import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
@@ -26,6 +27,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -143,6 +145,26 @@ public class UserController {
     public ApplicationResponse<UserProfileRes> getUserProfile(
             @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser) {
         return ApplicationResponse.ok(userService.getUserProfile(authenticatedUser));
+    }
+
+    @Auth(require = true)
+    @PutMapping("/profile")
+    @SecurityRequirement(name = "jwt-user-auth")
+    @Operation(summary = "인증된 사용자의 프로필 정보 수정", description = "인증된 사용자의 프로필 정보를 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(
+                responseCode = "409",
+                description =
+                        """
+                    (U0005)이미 등록된 닉네임입니다.<br>
+                    """,
+                content = @Content(schema = @Schema())),
+    })
+    public ApplicationResponse<Boolean> updateUserProfile(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser,
+            @RequestBody UserProfileUpdateReq userProfileUpdateReq) {
+        return ApplicationResponse.ok(
+                userService.updateUserProfile(authenticatedUser, userProfileUpdateReq));
     }
 
     private ResponseEntity<ApplicationResponse<UserLoginRes>> setRefreshToken(

--- a/src/main/java/everymeal/server/user/controller/UserController.java
+++ b/src/main/java/everymeal/server/user/controller/UserController.java
@@ -151,15 +151,12 @@ public class UserController {
     @PutMapping("/profile")
     @SecurityRequirement(name = "jwt-user-auth")
     @Operation(summary = "인증된 사용자의 프로필 정보 수정", description = "인증된 사용자의 프로필 정보를 수정합니다.")
-    @ApiResponses({
-        @ApiResponse(
-                responseCode = "409",
-                description =
-                        """
+    @ApiResponse(
+            responseCode = "409",
+            description = """
                     (U0005)이미 등록된 닉네임입니다.<br>
                     """,
-                content = @Content(schema = @Schema())),
-    })
+            content = @Content(schema = @Schema()))
     public ApplicationResponse<Boolean> updateUserProfile(
             @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser,
             @RequestBody UserProfileUpdateReq userProfileUpdateReq) {

--- a/src/main/java/everymeal/server/user/controller/UserController.java
+++ b/src/main/java/everymeal/server/user/controller/UserController.java
@@ -9,6 +9,7 @@ import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
 import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
+import everymeal.server.user.controller.dto.request.WithdrawalReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
@@ -162,6 +163,22 @@ public class UserController {
             @RequestBody UserProfileUpdateReq userProfileUpdateReq) {
         return ApplicationResponse.ok(
                 userService.updateUserProfile(authenticatedUser, userProfileUpdateReq));
+    }
+
+    @Auth(require = true)
+    @PostMapping("/withdrawal")
+    @SecurityRequirement(name = "jwt-user-auth")
+    @Operation(summary = "회원탈퇴", description = "서비스 회원 탈퇴를 합니다.")
+    @ApiResponse(
+            responseCode = "404",
+            description = """
+                    (U0001)등록된 유저가 아닙니다.<br>
+                    """,
+            content = @Content(schema = @Schema()))
+    public ApplicationResponse<Boolean> withdrawal(
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser authenticatedUser,
+            @RequestBody WithdrawalReq withdrawalReq) {
+        return ApplicationResponse.ok(userService.withdrawal(authenticatedUser, withdrawalReq));
     }
 
     private ResponseEntity<ApplicationResponse<UserLoginRes>> setRefreshToken(

--- a/src/main/java/everymeal/server/user/controller/dto/request/UserProfileUpdateReq.java
+++ b/src/main/java/everymeal/server/user/controller/dto/request/UserProfileUpdateReq.java
@@ -1,0 +1,9 @@
+package everymeal.server.user.controller.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserProfileUpdateReq(
+        @Schema(description = "닉네임", example = "연유크림") String nickName,
+        @Schema(description = "프로필 이미지 key", example = "user/bc90af33-bc6a-4009-bfc8-2c3efe0b16bd")
+                String profileImageKey) {}

--- a/src/main/java/everymeal/server/user/controller/dto/request/WithdrawalReq.java
+++ b/src/main/java/everymeal/server/user/controller/dto/request/WithdrawalReq.java
@@ -1,0 +1,12 @@
+package everymeal.server.user.controller.dto.request;
+
+
+import everymeal.server.user.entity.WithdrawalReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawalReq(
+        @NotBlank @Schema(description = "탈퇴 사유를 입력해주세요.", example = "NOT_USE_USUALLY")
+                WithdrawalReason withdrawalReason,
+        @Schema(description = "사유가 '기타'일 경우, 추가 이유 입력해주세요.", example = "다른 서비스를 사용하게 되었다.")
+                String etcReason) {}

--- a/src/main/java/everymeal/server/user/controller/dto/request/WithdrawalReq.java
+++ b/src/main/java/everymeal/server/user/controller/dto/request/WithdrawalReq.java
@@ -6,7 +6,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record WithdrawalReq(
-        @NotBlank @Schema(description = "탈퇴 사유를 입력해주세요.", example = "NOT_USE_USUALLY")
+        @NotBlank
+                @Schema(
+                        description = "탈퇴 사유를 입력해주세요.",
+                        example = "NOT_USE_USUALLY",
+                        allowableValues = {
+                            "NOT_USE_USUALLY",
+                            "INCONVENIENT_IN_TERMS_OF_USABILITY",
+                            "ERRORS_OCCUR_FREQUENTLY",
+                            "MY_SCHOOL_HAS_CHANGED",
+                            "ETC"
+                        })
                 WithdrawalReason withdrawalReason,
         @Schema(description = "사유가 '기타'일 경우, 추가 이유 입력해주세요.", example = "다른 서비스를 사용하게 되었다.")
                 String etcReason) {}

--- a/src/main/java/everymeal/server/user/controller/dto/response/UserProfileRes.java
+++ b/src/main/java/everymeal/server/user/controller/dto/response/UserProfileRes.java
@@ -5,11 +5,11 @@ import java.util.Map;
 
 public record UserProfileRes(
         Long userId, String nickName, String profileImgUrl, String universityName) {
-    public static UserProfileRes of(Map<String, Object> user) {
+    public static UserProfileRes of(Map<String, Object> user, String profileImgUrl) {
         return new UserProfileRes(
                 (Long) user.get("userId"),
                 (String) user.get("nickName"),
-                (String) user.get("profileImgUrl"),
+                profileImgUrl,
                 (String) user.get("universityName"));
     }
 }

--- a/src/main/java/everymeal/server/user/entity/Like.java
+++ b/src/main/java/everymeal/server/user/entity/Like.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,4 +27,10 @@ public class Like extends BaseEntity {
     @ManyToOne private Store store;
 
     @ManyToOne private User user;
+
+    @Builder
+    public Like(Store store, User user) {
+        this.store = store;
+        this.user = user;
+    }
 }

--- a/src/main/java/everymeal/server/user/entity/User.java
+++ b/src/main/java/everymeal/server/user/entity/User.java
@@ -65,4 +65,9 @@ public class User extends BaseEntity {
     public void setEmail(String email) {
         this.email = email;
     }
+
+    public void updateProfile(String nickname, String profileImgUrl) {
+        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
+    }
 }

--- a/src/main/java/everymeal/server/user/entity/User.java
+++ b/src/main/java/everymeal/server/user/entity/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;
@@ -53,6 +54,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     Set<ReviewMark> reviewMarks = new HashSet<>();
 
+    @OneToOne(mappedBy = "user")
+    private Withdrawal withdrawal;
+
     @Builder
     public User(String nickname, String email, String profileImgUrl, University university) {
         this.nickname = nickname;
@@ -69,5 +73,9 @@ public class User extends BaseEntity {
     public void updateProfile(String nickname, String profileImgUrl) {
         this.nickname = nickname;
         this.profileImgUrl = profileImgUrl;
+    }
+    /** 회원 탈퇴 */
+    public void setIsDeleted() {
+        this.isDeleted = Boolean.TRUE;
     }
 }

--- a/src/main/java/everymeal/server/user/entity/Withdrawal.java
+++ b/src/main/java/everymeal/server/user/entity/Withdrawal.java
@@ -25,7 +25,7 @@ public class Withdrawal extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private WithdrawalReason withdrawalReason;
 
-    @Column(nullable = true, length = 100)
+    @Column(nullable = true, columnDefinition = "TEXT")
     private String etcReason;
 
     @MapsId

--- a/src/main/java/everymeal/server/user/entity/Withdrawal.java
+++ b/src/main/java/everymeal/server/user/entity/Withdrawal.java
@@ -1,0 +1,42 @@
+package everymeal.server.user.entity;
+
+
+import everymeal.server.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Withdrawal extends BaseEntity {
+    @Id private Long userIdx;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private WithdrawalReason withdrawalReason;
+
+    @Column(nullable = true, length = 100)
+    private String etcReason;
+
+    @MapsId
+    @OneToOne
+    @JoinColumn(name = "user_idx", referencedColumnName = "idx")
+    private User user;
+
+    @Builder
+    public Withdrawal(WithdrawalReason withdrawalReason, String etcReason, User user) {
+        this.withdrawalReason = withdrawalReason;
+        this.etcReason = etcReason;
+        this.user = user;
+    }
+}

--- a/src/main/java/everymeal/server/user/entity/WithdrawalReason.java
+++ b/src/main/java/everymeal/server/user/entity/WithdrawalReason.java
@@ -1,0 +1,17 @@
+package everymeal.server.user.entity;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WithdrawalReason {
+    NOT_USE_USUALLY("앱을 잘 쓰지 않아요"),
+    INCONVENIENT_IN_TERMS_OF_USABILITY("사용성이 불편해요"),
+    ERRORS_OCCUR_FREQUENTLY("오류가 자주 발생해요"),
+    MY_SCHOOL_HAS_CHANGED("학교가 바뀌었어요"),
+    ETC("기타");
+
+    public final String MESSAGE;
+}

--- a/src/main/java/everymeal/server/user/repository/LikeRepository.java
+++ b/src/main/java/everymeal/server/user/repository/LikeRepository.java
@@ -1,0 +1,12 @@
+package everymeal.server.user.repository;
+
+
+import everymeal.server.store.entity.Store;
+import everymeal.server.user.entity.Like;
+import everymeal.server.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByUserAndStore(User user, Store store);
+}

--- a/src/main/java/everymeal/server/user/repository/WithdrawalRepository.java
+++ b/src/main/java/everymeal/server/user/repository/WithdrawalRepository.java
@@ -1,0 +1,7 @@
+package everymeal.server.user.repository;
+
+
+import everymeal.server.user.entity.Withdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawalRepository extends JpaRepository<Withdrawal, Long> {}

--- a/src/main/java/everymeal/server/user/service/UserService.java
+++ b/src/main/java/everymeal/server/user/service/UserService.java
@@ -5,6 +5,7 @@ import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
 import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
+import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
@@ -22,4 +23,7 @@ public interface UserService {
     Boolean checkUser(String email);
 
     UserProfileRes getUserProfile(AuthenticatedUser authenticatedUser);
+
+    Boolean updateUserProfile(
+            AuthenticatedUser authenticatedUser, UserProfileUpdateReq userProfileUpdateReq);
 }

--- a/src/main/java/everymeal/server/user/service/UserService.java
+++ b/src/main/java/everymeal/server/user/service/UserService.java
@@ -6,6 +6,7 @@ import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
 import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
+import everymeal.server.user.controller.dto.request.WithdrawalReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
@@ -26,4 +27,6 @@ public interface UserService {
 
     Boolean updateUserProfile(
             AuthenticatedUser authenticatedUser, UserProfileUpdateReq userProfileUpdateReq);
+
+    Boolean withdrawal(AuthenticatedUser authenticatedUser, WithdrawalReq request);
 }

--- a/src/main/java/everymeal/server/user/service/UserServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/UserServiceImpl.java
@@ -196,7 +196,7 @@ public class UserServiceImpl implements UserService {
                             .user(user)
                             .build();
         } else // 기타를 선택한 경우
-            withdrawal =
+        withdrawal =
                     Withdrawal.builder()
                             .withdrawalReason(request.withdrawalReason())
                             .etcReason(request.etcReason()) // 글자수 제한이 있는지 처리 X

--- a/src/main/java/everymeal/server/user/service/UserServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/UserServiceImpl.java
@@ -199,7 +199,7 @@ public class UserServiceImpl implements UserService {
         withdrawal =
                     Withdrawal.builder()
                             .withdrawalReason(request.withdrawalReason())
-                            .etcReason(request.etcReason()) // 글자수 제한이 있는지 처리 X
+                            .etcReason(request.etcReason())
                             .user(user)
                             .build();
         withdrawalRepository.save(withdrawal); // 탈퇴 관련 정보 저장

--- a/src/main/java/everymeal/server/user/service/UserServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/UserServiceImpl.java
@@ -13,12 +13,16 @@ import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
 import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
+import everymeal.server.user.controller.dto.request.WithdrawalReq;
 import everymeal.server.user.controller.dto.response.UserEmailAuthRes;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import everymeal.server.user.controller.dto.response.UserProfileRes;
 import everymeal.server.user.entity.User;
+import everymeal.server.user.entity.Withdrawal;
+import everymeal.server.user.entity.WithdrawalReason;
 import everymeal.server.user.repository.UserMapper;
 import everymeal.server.user.repository.UserRepository;
+import everymeal.server.user.repository.WithdrawalRepository;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Map;
@@ -39,6 +43,7 @@ public class UserServiceImpl implements UserService {
     private final MailUtil mailUtil;
     private final S3Util s3Util;
     private final UserMapper userMapper;
+    private final WithdrawalRepository withdrawalRepository;
 
     @Override
     @Transactional
@@ -173,6 +178,32 @@ public class UserServiceImpl implements UserService {
             throw new ApplicationException(ExceptionList.NICKNAME_ALREADY_EXIST);
         }
         user.updateProfile(request.nickName(), request.profileImageKey());
+        return true;
+    }
+
+    @Override
+    @Transactional
+    public Boolean withdrawal(AuthenticatedUser authenticatedUser, WithdrawalReq request) {
+        User user =
+                userRepository
+                        .findById(authenticatedUser.getIdx())
+                        .orElseThrow(() -> new ApplicationException(ExceptionList.USER_NOT_FOUND));
+        Withdrawal withdrawal;
+        if (request.withdrawalReason() != WithdrawalReason.ETC) { // 기타를 제외한 경우
+            withdrawal =
+                    Withdrawal.builder()
+                            .withdrawalReason(request.withdrawalReason())
+                            .user(user)
+                            .build();
+        } else // 기타를 선택한 경우
+            withdrawal =
+                    Withdrawal.builder()
+                            .withdrawalReason(request.withdrawalReason())
+                            .etcReason(request.etcReason()) // 글자수 제한이 있는지 처리 X
+                            .user(user)
+                            .build();
+        withdrawalRepository.save(withdrawal); // 탈퇴 관련 정보 저장
+        user.setIsDeleted(); // 논리 삭제
         return true;
     }
 }

--- a/src/main/resources/mybatis/mappers/StoreMapper.xml
+++ b/src/main/resources/mybatis/mappers/StoreMapper.xml
@@ -136,4 +136,120 @@
          ) total
   </select>
 
+  <select id="getUserLikesStore">
+    SELECT *
+    FROM (
+      SELECT
+      s.idx as 'idx',
+      s.name as 'name',
+      s.address as 'address',
+      s.phone as 'phoneNumber',
+      s.category_detail as 'categoryDetail',
+      s.distance as 'distance',
+      s.grade as 'grade',
+      s.review_count as 'reviewCount',
+      s.recommended_count as 'recommendedCount',
+      GROUP_CONCAT(i.image_url SEPARATOR ',') AS 'images',
+      true AS 'isLiked' ,
+      COUNT(DISTINCT l.idx) AS 'userLikesCount'
+    FROM
+      store s
+        LEFT JOIN
+      reviews r ON s.idx = r.store_idx AND r.is_deleted = false
+        LEFT JOIN
+      images i ON r.idx = i.review_idx AND i.is_deleted = false
+        JOIN
+      likes l ON s.idx = l.store_idx
+    WHERE
+      l.user_idx = #{userIdx}
+      AND s.university_idx = #{universityIdx}
+      AND s.is_deleted = FALSE
+      AND (
+      CASE
+        WHEN #{group} = 'recommend' THEN s.recommended_count > 0
+        WHEN #{group} = 'restaurant' THEN s.category_detail IN ('한식', '중식', '일식', '양식')
+        WHEN #{group} = 'cafe' THEN s.category_detail IN ('카페', '디저트')
+        WHEN #{group} = 'bar' THEN s.category_detail = '술집'
+        WHEN #{group} = 'all' THEN 1=1
+        ELSE s.category_detail IN ('한식', '중식', '일식', '양식', '카페', '디저트', '술집', '기타', '패스트푸드', '분식')
+        END
+      )
+      AND (
+      CASE
+        WHEN #{grade} = 1 THEN s.grade BETWEEN 0 AND 1
+        WHEN #{grade} = 2 THEN s.grade BETWEEN 1 AND 2
+        WHEN #{grade} = 3 THEN s.grade BETWEEN 2 AND 3
+        WHEN #{grade} = 4 THEN s.grade BETWEEN 3 AND 4
+        WHEN #{grade} = 5 THEN s.grade BETWEEN 4 AND 5
+        ELSE s.grade BETWEEN 0 AND 5
+        END
+      )
+    GROUP BY
+      s.idx, s.name, s.address, s.phone, s.category_detail, s.distance, s.grade, s.review_count, s.recommended_count
+    ORDER BY
+      CASE #{order}
+        WHEN 'name' THEN s.name
+        WHEN 'distance' THEN s.distance
+        WHEN 'recommendedCount' THEN s.recommended_count
+        WHEN 'reviewCount' THEN s.review_count
+        WHEN 'grade' THEN s.grade
+        WHEN 'registDate' THEN s.created_at
+        ELSE s.idx
+        END DESC
+      ) a
+      LIMIT #{limit}
+    OFFSET #{offset}
+  </select>
+  <select id="getUserLikesStoreCount">
+    SELECT
+      COUNT(*) AS total
+    FROM (
+    SELECT
+      s.idx
+    FROM
+      store s
+        LEFT JOIN
+      reviews r ON s.idx = r.store_idx AND r.is_deleted = false
+        LEFT JOIN
+      images i ON r.idx = i.review_idx AND i.is_deleted = false
+        JOIN
+      likes l ON s.idx = l.store_idx
+    WHERE
+      l.user_idx = #{userIdx}
+      AND s.university_idx = #{universityIdx}
+      AND s.is_deleted = FALSE
+      AND (
+      CASE
+        WHEN #{group} = 'recommend' THEN s.recommended_count > 0
+        WHEN #{group} = 'restaurant' THEN s.category_detail IN ('한식', '중식', '일식', '양식')
+        WHEN #{group} = 'cafe' THEN s.category_detail IN ('카페', '디저트')
+        WHEN #{group} = 'bar' THEN s.category_detail = '술집'
+        WHEN #{group} = 'all' THEN 1=1
+        ELSE s.category_detail IN ('한식', '중식', '일식', '양식', '카페', '디저트', '술집', '기타', '패스트푸드', '분식')
+        END
+      )
+      AND (
+      CASE
+        WHEN #{grade} = 1 THEN s.grade BETWEEN 0 AND 1
+        WHEN #{grade} = 2 THEN s.grade BETWEEN 1 AND 2
+        WHEN #{grade} = 3 THEN s.grade BETWEEN 2 AND 3
+        WHEN #{grade} = 4 THEN s.grade BETWEEN 3 AND 4
+        WHEN #{grade} = 5 THEN s.grade BETWEEN 4 AND 5
+        ELSE s.grade BETWEEN 0 AND 5
+        END
+      )
+    GROUP BY
+      s.idx, s.name, s.address, s.phone, s.category_detail, s.distance, s.grade, s.review_count, s.recommended_count
+    ORDER BY
+      CASE #{order}
+        WHEN 'name' THEN s.name
+        WHEN 'distance' THEN s.distance
+        WHEN 'recommendedCount' THEN s.recommended_count
+        WHEN 'reviewCount' THEN s.review_count
+        WHEN 'grade' THEN s.grade
+        WHEN 'registDate' THEN s.created_at
+        ELSE s.idx
+        END DESC
+      ) total
+  </select>
 </mapper>

--- a/src/test/java/everymeal/server/store/controller/StoreControllerTest.java
+++ b/src/test/java/everymeal/server/store/controller/StoreControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -128,6 +129,46 @@ class StoreControllerTest extends ControllerTestSupport {
                                 .param("limit", String.valueOf(limit))
                                 .param("order", order)
                                 .param("group", group))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("인증된 사용자의 저장 목록 조회")
+    @Test
+    void getUserLikesStore() throws Exception {
+        // given
+        Long campusIdx = 1L;
+        int offset = 0;
+        int limit = 10;
+        String group = "all";
+
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
+
+        // when then
+        mockMvc.perform(
+                        get("/api/v1/stores/likes")
+                                .param("campusIdx", String.valueOf(campusIdx))
+                                .param("offset", String.valueOf(offset))
+                                .param("limit", String.valueOf(limit))
+                                .param("group", group))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("가게 저장 / 저장 해제")
+    @Test
+    void likesStore_like() throws Exception {
+        // given
+        Long storeIdx = 1L;
+
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
+
+        // when then
+        mockMvc.perform(post("/api/v1/stores/likes/{storeIdx}", storeIdx))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("OK"));

--- a/src/test/java/everymeal/server/store/service/StoreServiceImplTest.java
+++ b/src/test/java/everymeal/server/store/service/StoreServiceImplTest.java
@@ -4,6 +4,9 @@ import static everymeal.server.store.entity.StoreSortVo.SORT_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import everymeal.server.global.IntegrationTestSupport;
+import everymeal.server.global.util.JwtUtil;
+import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
+import everymeal.server.store.controller.dto.response.LikedStoreGetRes;
 import everymeal.server.store.controller.dto.response.StoreGetRes;
 import everymeal.server.store.entity.Store;
 import everymeal.server.store.repository.StoreMapper;
@@ -11,6 +14,13 @@ import everymeal.server.store.repository.StoreRepository;
 import everymeal.server.store.repository.StoreRepositoryCustom;
 import everymeal.server.university.entity.University;
 import everymeal.server.university.repository.UniversityRepository;
+import everymeal.server.user.controller.dto.request.UserEmailSingReq;
+import everymeal.server.user.controller.dto.response.UserLoginRes;
+import everymeal.server.user.entity.Like;
+import everymeal.server.user.entity.User;
+import everymeal.server.user.repository.LikeRepository;
+import everymeal.server.user.repository.UserRepository;
+import everymeal.server.user.service.UserService;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +38,10 @@ class StoreServiceImplTest extends IntegrationTestSupport {
     @Autowired private StoreMapper storeMapper;
     @Autowired private StoreRepositoryCustom storeRepositoryCustom;
     @Autowired private EntityManager entityManager;
+    @Autowired private JwtUtil jwtUtil;
+    @Autowired private UserService userService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private LikeRepository likeRepository;
 
     @DisplayName("캠퍼스 기준 식당 가져오기")
     @Transactional
@@ -64,6 +78,121 @@ class StoreServiceImplTest extends IntegrationTestSupport {
                 .hasSize(3)
                 .extracting("name")
                 .containsExactly("store3", "store2", "store1");
+    }
+
+    @DisplayName("캠퍼스 기준 저장한 식당 가져오기")
+    @Transactional
+    @Test
+    void getUserLikesStore() throws Exception {
+        // given
+        University save =
+                universityRepository.save(
+                        University.builder().name("서울대학교").campusName("관악캠퍼스").build());
+
+        Long campusIdx = save.getIdx();
+        int offset = 0;
+        int limit = 10;
+        PageRequest pageRequest = PageRequest.of(offset, limit);
+
+        List<Store> entity =
+                List.of(
+                        createEntity("store1", 3, save),
+                        createEntity("store2", 2, save),
+                        createEntity("store3", 1, save));
+
+        String token = jwtUtil.generateEmailToken("test@gmail.com", "12345");
+
+        UserEmailSingReq request =
+                new UserEmailSingReq("연유크림", token, "12345", save.getIdx(), "imageKey");
+
+        UserLoginRes userLoginRes = userService.signUp(request);
+
+        AuthenticatedUser user =
+                jwtUtil.getAuthenticateUserFromAccessToken(userLoginRes.accessToken());
+        User userEntity = userRepository.findByNickname("연유크림").get();
+        List<Like> likes =
+                List.of(
+                        createLikeEntity(entity.get(0), userEntity),
+                        createLikeEntity(entity.get(1), userEntity),
+                        createLikeEntity(entity.get(2), userEntity));
+        storeRepository.saveAll(entity);
+        storeRepository.flush();
+        likeRepository.saveAll(likes);
+        likeRepository.flush();
+        entityManager.clear();
+
+        // when
+        Page<LikedStoreGetRes> stores =
+                storeService.getUserLikesStore(campusIdx, pageRequest, "all", user);
+
+        // then
+        assertThat(stores.getContent())
+                .hasSize(3)
+                .extracting("name")
+                .containsExactly("store3", "store2", "store1");
+    }
+
+    @DisplayName("가게 저장")
+    @Test
+    @Transactional
+    void likesStore() {
+        // given
+        University save =
+                universityRepository.save(
+                        University.builder().name("서울대학교").campusName("관악캠퍼스").build());
+
+        Store store = createEntity("store1", 3, save);
+        storeRepository.saveAndFlush(store);
+        String token = jwtUtil.generateEmailToken("test@gmail.com", "12345");
+
+        UserEmailSingReq request =
+                new UserEmailSingReq("연유크림", token, "12345", save.getIdx(), "imageKey");
+
+        UserLoginRes userLoginRes = userService.signUp(request);
+
+        AuthenticatedUser user =
+                jwtUtil.getAuthenticateUserFromAccessToken(userLoginRes.accessToken());
+        User userEntity = userRepository.findByNickname("연유크림").get();
+
+        // when
+        var response = storeService.likesStore(store.getIdx(), user);
+        var result = likeRepository.findByUserAndStore(userEntity, store);
+        // then
+        assertThat(result.isPresent());
+    }
+
+    @DisplayName("가게 저장 해제")
+    @Test
+    @Transactional
+    void unlikesStore() {
+        // given
+        University save =
+                universityRepository.save(
+                        University.builder().name("서울대학교").campusName("관악캠퍼스").build());
+
+        Store store = createEntity("store1", 3, save);
+        storeRepository.saveAndFlush(store);
+        String token = jwtUtil.generateEmailToken("test@gmail.com", "12345");
+
+        UserEmailSingReq request =
+                new UserEmailSingReq("연유크림", token, "12345", save.getIdx(), "imageKey");
+
+        UserLoginRes userLoginRes = userService.signUp(request);
+
+        AuthenticatedUser user =
+                jwtUtil.getAuthenticateUserFromAccessToken(userLoginRes.accessToken());
+        User userEntity = userRepository.findByNickname("연유크림").get();
+        Like like = createLikeEntity(store, userEntity);
+        likeRepository.saveAndFlush(like);
+        // when
+        var response = storeService.likesStore(store.getIdx(), user);
+        var result = likeRepository.findByUserAndStore(userEntity, store);
+        // then
+        assertThat(!result.isPresent());
+    }
+
+    private Like createLikeEntity(Store store, User user) {
+        return Like.builder().store(store).user(user).build();
     }
 
     private Store createEntity(String name, int distance, University university) {

--- a/src/test/java/everymeal/server/user/controller/UserControllerTest.java
+++ b/src/test/java/everymeal/server/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -14,6 +15,7 @@ import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
 import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
+import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -130,6 +132,25 @@ class UserControllerTest extends ControllerTestSupport {
                 .willReturn(AuthenticatedUser.builder().idx(1L).build());
         // when-then
         mockMvc.perform(get("/api/v1/users/profile").contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("인증된 유저의 프로필 정보 수정")
+    @Test
+    void updateUserProfile() throws Exception {
+        // given
+        UserProfileUpdateReq request = new UserProfileUpdateReq("연유크림", "imageKey");
+
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
+
+        // when-then
+        mockMvc.perform(
+                        put("/api/v1/users/profile")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("OK"));

--- a/src/test/java/everymeal/server/user/controller/UserControllerTest.java
+++ b/src/test/java/everymeal/server/user/controller/UserControllerTest.java
@@ -16,7 +16,9 @@ import everymeal.server.user.controller.dto.request.UserEmailAuthReq;
 import everymeal.server.user.controller.dto.request.UserEmailLoginReq;
 import everymeal.server.user.controller.dto.request.UserEmailSingReq;
 import everymeal.server.user.controller.dto.request.UserProfileUpdateReq;
+import everymeal.server.user.controller.dto.request.WithdrawalReq;
 import everymeal.server.user.controller.dto.response.UserLoginRes;
+import everymeal.server.user.entity.WithdrawalReason;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -149,6 +151,25 @@ class UserControllerTest extends ControllerTestSupport {
         // when-then
         mockMvc.perform(
                         put("/api/v1/users/profile")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @DisplayName("회원 탈퇴")
+    @Test
+    void withdrawal() throws Exception {
+        // given
+        WithdrawalReq request = new WithdrawalReq(WithdrawalReason.ERRORS_OCCUR_FREQUENTLY, "");
+
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
+
+        // when-then
+        mockMvc.perform(
+                        post("/api/v1/users/withdrawal")
                                 .content(objectMapper.writeValueAsString(request))
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())


### PR DESCRIPTION
## 작업 내용
마이페이지-저장목록 조회 및 가게저장 API 개발

## 관련 이슈
#68 

## 작업 확인 방법

```` json

{
  "localDateTime": "2023-11-26T18:43:14.898042",
  "message": "OK",
  "data": {
    "content": [
      {
        "idx": 386,
        "name": "히포 브런치하우스",
        "address": "서울 마포구 연남동 487-34",
        "phoneNumber": "010-3796-3176",
        "categoryDetail": "카페",
        "distance": 1721,
        "grade": 0,
        "reviewCount": 0,
        "recommendedCount": 0,
        "images": null,
        "isLiked": true, // 저장인 경우
        "userLikesCount": 1 // 저장 카운트
      }
    ],
    "pageable": {
      "sort": {
        "empty": true,
        "sorted": false,
        "unsorted": true
      },
      "offset": 0,
      "pageNumber": 0,
      "pageSize": 10,
      "paged": true,
      "unpaged": false
    },
    "last": true,
    "totalPages": 1,
    "totalElements": 1,
    "first": true,
    "size": 10,
    "number": 0,
    "sort": {
      "empty": true,
      "sorted": false,
      "unsorted": true
    },
    "numberOfElements": 1,
    "empty": false
  }
}

````

## 추가 정보 (선택 사항)

StoreGetRes 레코드를 사용하려고 했으나 피그마 UI 상 `userLikesCount`가 추가로 필요해서 record를 새롭게 정의했습니다.

**🙋🏻‍♀️질문 !!!** 

가게를 저장하고 저장 해제하는 것을 하나의 API에서 처리하도록 구현했는데, 혹시 분리되어야 한다고 생각하시나요??