### PR TITLE
[Feature/report review] 식당 리뷰 신고하기 기능 개발 및 코드 리펙토링

### DIFF
--- a/src/main/java/everymeal/server/global/exception/ExceptionList.java
+++ b/src/main/java/everymeal/server/global/exception/ExceptionList.java
@@ -8,27 +8,33 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ExceptionList {
-    MEAL_NOT_FOUND("M0001", HttpStatus.NOT_FOUND, "Meal Not Found"),
-    RESTAURANT_NOT_FOUND("M0002", HttpStatus.NOT_FOUND, "등록된 식당이 아닙니다."),
-    UNIVERSITY_NOT_FOUND("M0003", HttpStatus.NOT_FOUND, "등록된 학교가 아닙니다."),
+    MEAL_NOT_FOUND("MEL0001", HttpStatus.NOT_FOUND, "Meal Not Found"),
+    RESTAURANT_NOT_FOUND("MEL0002", HttpStatus.NOT_FOUND, "등록된 식당이 아닙니다."),
+    UNIVERSITY_NOT_FOUND("MEL0003", HttpStatus.NOT_FOUND, "등록된 학교가 아닙니다."),
     INVALID_MEAL_OFFEREDAT_REQUEST(
-            "M0004", HttpStatus.BAD_REQUEST, "동일한 데이터를 갖는 식단 데이터가 이미 존재합니다."),
-    INVALID_REQUEST("R0001", HttpStatus.BAD_REQUEST, "Request의 Data Type이 올바르지 않습니다."),
+            "MEL0004", HttpStatus.BAD_REQUEST, "동일한 데이터를 갖는 식단 데이터가 이미 존재합니다."),
+    INVALID_REQUEST("COM0001", HttpStatus.BAD_REQUEST, "Request의 Data Type이 올바르지 않습니다."),
 
-    USER_NOT_FOUND("U0001", HttpStatus.NOT_FOUND, "등록된 유저가 아닙니다."),
-    USER_AUTH_TIME_OUT("U0002", HttpStatus.FORBIDDEN, "인증 시간이 만료되었습니다."),
-    USER_AUTH_FAIL("U0003", HttpStatus.FORBIDDEN, "인증에 실패하였습니다."),
-    USER_ALREADY_EXIST("U0004", HttpStatus.CONFLICT, "이미 등록된 이메일입니다."),
-    NICKNAME_ALREADY_EXIST("U0005", HttpStatus.CONFLICT, "이미 등록된 닉네임입니다."),
+    USER_NOT_FOUND("USR0001", HttpStatus.NOT_FOUND, "등록된 유저가 아닙니다."),
+    USER_AUTH_TIME_OUT("USR0002", HttpStatus.FORBIDDEN, "인증 시간이 만료되었습니다."),
+    USER_AUTH_FAIL("USR0003", HttpStatus.FORBIDDEN, "인증에 실패하였습니다."),
+    USER_ALREADY_EXIST("USR0004", HttpStatus.CONFLICT, "이미 등록된 이메일입니다."),
+    NICKNAME_ALREADY_EXIST("USR0005", HttpStatus.CONFLICT, "이미 등록된 닉네임입니다."),
 
-    TOKEN_NOT_VALID("T0001", HttpStatus.NOT_ACCEPTABLE, "해당 토큰은 유효하지 않습니다."),
-    TOKEN_EXPIRATION("T0002", HttpStatus.FORBIDDEN, "토큰이 만료되었습니다."),
+    TOKEN_NOT_VALID("TKN0001", HttpStatus.NOT_ACCEPTABLE, "해당 토큰은 유효하지 않습니다."),
+    TOKEN_EXPIRATION("TKN0002", HttpStatus.FORBIDDEN, "토큰이 만료되었습니다."),
 
     REVIEW_NOT_FOUND("RV0001", HttpStatus.NOT_FOUND, "등록된 리뷰가 아닙니다."),
     REVIEW_UNAUTHORIZED("RV0002", HttpStatus.FORBIDDEN, "해당 리뷰에 대한 권한이 없습니다."),
     REVIEW_ALREADY_MARKED("RV0003", HttpStatus.CONFLICT, "이미 해당 리뷰에 대한 평가를 하였습니다."),
     REVIEW_MARK_NOT_FOUND("RV0004", HttpStatus.NOT_FOUND, "등록된 리뷰 평가가 아닙니다."),
-    STORE_NOT_FOUND("S0001", HttpStatus.NOT_FOUND, "등록된 가게가 아닙니다."),
+    STORE_NOT_FOUND("STR0001", HttpStatus.NOT_FOUND, "등록된 가게가 아닙니다."),
+
+    // report
+    REPORT_NOT_FOUND("RPT0001", HttpStatus.NOT_FOUND, "등록된 신고가 아닙니다."),
+    REPORT_ALREADY_EXIST("RPT0002", HttpStatus.CONFLICT, "이미 신고한 리뷰입니다."),
+    REPORT_REVIEW_SELF("RPT0003", HttpStatus.FORBIDDEN, "자신의 리뷰를 신고할 수 없습니다."),
+    REPORT_REVIEW_ALREADY("RPT0004", HttpStatus.CONFLICT, "이미 신고한 리뷰입니다."),
     ;
 
     public final String CODE;

--- a/src/main/java/everymeal/server/meal/repository/MealMapper.java
+++ b/src/main/java/everymeal/server/meal/repository/MealMapper.java
@@ -16,11 +16,6 @@ public interface MealMapper {
             @Param("universityName") String universityName,
             @Param("campusName") String campusName);
 
-    List<Map<String, Object>> findWeekList(
-            @Param("weeklyDates") List<String> weeklyDates,
-            @Param("universityName") String universityName,
-            @Param("campusName") String campusName);
-
     List<Meal> findAllByOfferedAtOnDateAndMealType(
             @Param("offeredAt") String offeredAt,
             @Param("mealType") String mealType,

--- a/src/main/java/everymeal/server/meal/service/MealCommServiceImpl.java
+++ b/src/main/java/everymeal/server/meal/service/MealCommServiceImpl.java
@@ -1,0 +1,35 @@
+package everymeal.server.meal.service;
+
+
+import everymeal.server.meal.entity.Meal;
+import everymeal.server.meal.repository.MealDao;
+import everymeal.server.meal.repository.MealMapper;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MealCommServiceImpl {
+
+    private final MealDao mealDao; // JPQL DAO
+    private final MealMapper mealMapper; // MyBatis DAO
+
+    public List<Meal> getMealAllByOfferedAtOnDateAndMealType(
+            String offeredAt, String mealType, Long restaurantIdx) {
+        return mealMapper.findAllByOfferedAtOnDateAndMealType(offeredAt, mealType, restaurantIdx);
+    }
+
+    @Transactional
+    public void saveAll(List<Meal> mealList) {
+        mealDao.saveAll(mealList);
+    }
+
+    public List<Map<String, Object>> getDayList(
+            String offeredAt, String universityName, String campusName) {
+        return mealMapper.findDayList(offeredAt, universityName, campusName);
+    }
+}

--- a/src/main/java/everymeal/server/meal/service/RestaurantCommServiceImpl.java
+++ b/src/main/java/everymeal/server/meal/service/RestaurantCommServiceImpl.java
@@ -1,0 +1,40 @@
+package everymeal.server.meal.service;
+
+import static everymeal.server.global.exception.ExceptionList.RESTAURANT_NOT_FOUND;
+
+import everymeal.server.global.exception.ApplicationException;
+import everymeal.server.meal.entity.Restaurant;
+import everymeal.server.meal.repository.RestaurantRepository;
+import everymeal.server.university.entity.University;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class RestaurantCommServiceImpl {
+
+    private final RestaurantRepository restaurantRepository;
+
+    public Optional<Restaurant> getRestaurantOptionalEntity(Long restaurantIdx) {
+        return restaurantRepository.findById(restaurantIdx);
+    }
+
+    public Restaurant getRestaurantEntity(Long restaurantIdx) {
+        return restaurantRepository
+                .findById(restaurantIdx)
+                .orElseThrow(() -> new ApplicationException(RESTAURANT_NOT_FOUND));
+    }
+
+    @Transactional
+    public Restaurant save(Restaurant restaurant) {
+        return restaurantRepository.save(restaurant);
+    }
+
+    public List<Restaurant> getAllByUniversityAndIsDeletedFalse(University university) {
+        return restaurantRepository.findAllByUniversityAndIsDeletedFalse(university);
+    }
+}

--- a/src/main/java/everymeal/server/meal/service/RestaurantService.java
+++ b/src/main/java/everymeal/server/meal/service/RestaurantService.java
@@ -3,7 +3,6 @@ package everymeal.server.meal.service;
 
 import everymeal.server.meal.controller.dto.request.RestaurantRegisterReq;
 import everymeal.server.meal.entity.Restaurant;
-import everymeal.server.university.entity.University;
 import java.util.List;
 
 public interface RestaurantService {
@@ -12,5 +11,5 @@ public interface RestaurantService {
 
     Boolean createRestaurant(RestaurantRegisterReq restaurantRegisterReq);
 
-    List<Restaurant> getAllByUniversityAndIsDeletedFalse(University university);
+    List<Restaurant> getAllByUniversityAndIsDeletedFalse(String universityName, String campusName);
 }

--- a/src/main/java/everymeal/server/meal/service/RestaurantServiceImpl.java
+++ b/src/main/java/everymeal/server/meal/service/RestaurantServiceImpl.java
@@ -5,7 +5,6 @@ import everymeal.server.global.exception.ApplicationException;
 import everymeal.server.global.exception.ExceptionList;
 import everymeal.server.meal.controller.dto.request.RestaurantRegisterReq;
 import everymeal.server.meal.entity.Restaurant;
-import everymeal.server.meal.repository.RestaurantRepository;
 import everymeal.server.university.entity.University;
 import everymeal.server.university.service.UniversityService;
 import java.util.List;
@@ -18,13 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class RestaurantServiceImpl implements RestaurantService {
 
-    private final RestaurantRepository restaurantRepository;
+    private final RestaurantCommServiceImpl restaurantCommServiceImpl;
     private final UniversityService universityServiceImpl;
 
     @Override
     public Restaurant getRestaurant(Long restaurantIdx) {
-        return restaurantRepository
-                .findById(restaurantIdx)
+        return restaurantCommServiceImpl
+                .getRestaurantOptionalEntity(restaurantIdx)
                 .orElseThrow(() -> new ApplicationException(ExceptionList.RESTAURANT_NOT_FOUND));
     }
 
@@ -41,11 +40,15 @@ public class RestaurantServiceImpl implements RestaurantService {
                         .restaurantRegisterReq(restaurantRegisterReq)
                         .university(university)
                         .build();
-        return restaurantRepository.save(restaurant).getIdx() != null;
+        return restaurantCommServiceImpl.save(restaurant).getIdx() != null;
     }
 
     @Override
-    public List<Restaurant> getAllByUniversityAndIsDeletedFalse(University university) {
-        return restaurantRepository.findAllByUniversityAndIsDeletedFalse(university);
+    public List<Restaurant> getAllByUniversityAndIsDeletedFalse(
+            String universityName, String campusName) {
+        // 학교 등록 여부 판단
+        University university = universityServiceImpl.getUniversity(universityName, campusName);
+
+        return restaurantCommServiceImpl.getAllByUniversityAndIsDeletedFalse(university);
     }
 }

--- a/src/main/java/everymeal/server/report/controller/ReportController.java
+++ b/src/main/java/everymeal/server/report/controller/ReportController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/reports")
 @RequiredArgsConstructor
 @RestController
+@Tag(name = "Report API", description = "리뷰 신고 관련 API입니다.")
 public class ReportController {
 
     private final ReportService reportService;
@@ -47,7 +49,7 @@ public class ReportController {
     @SecurityRequirement(name = "jwt-user-auth")
     public ApplicationResponse<Boolean> reportReview(
             @Schema(description = "리뷰 아이디") @PathVariable Long reviewIdx,
-            @Schema(description = "리뷰 신고 사유") @RequestBody @Valid ReportDto.ReportReviewReq request,
+            @RequestBody @Valid ReportDto.ReportReviewReq request,
             @Parameter(hidden = true) @AuthUser AuthenticatedUser user) {
         return ApplicationResponse.ok(
                 reportService.reportReview(reviewIdx, request, user.getIdx()));

--- a/src/main/java/everymeal/server/report/controller/ReportController.java
+++ b/src/main/java/everymeal/server/report/controller/ReportController.java
@@ -1,0 +1,55 @@
+package everymeal.server.report.controller;
+
+
+import everymeal.server.global.dto.response.ApplicationResponse;
+import everymeal.server.global.util.authresolver.Auth;
+import everymeal.server.global.util.authresolver.AuthUser;
+import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
+import everymeal.server.report.dto.ReportDto;
+import everymeal.server.report.service.ReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+@RestController
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping("/review/{reviewIdx}")
+    @Operation(
+            summary = "리뷰 신고",
+            description =
+                    """
+              리뷰 신고를 진행합니다. <br>
+              로그인이 필요한 기능입니다.
+              """)
+    @ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "리뷰 신고 성공",
+                content = @Content(schema = @Schema())),
+    })
+    @Auth(require = true)
+    @SecurityRequirement(name = "jwt-user-auth")
+    public ApplicationResponse<Boolean> reportReview(
+            @Schema(description = "리뷰 아이디") @PathVariable Long reviewIdx,
+            @Schema(description = "리뷰 신고 사유") @RequestBody @Valid ReportDto.ReportReviewReq request,
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser user) {
+        return ApplicationResponse.ok(
+                reportService.reportReview(reviewIdx, request, user.getIdx()));
+    }
+}

--- a/src/main/java/everymeal/server/report/dto/ReportDto.java
+++ b/src/main/java/everymeal/server/report/dto/ReportDto.java
@@ -9,8 +9,7 @@ public class ReportDto {
 
     public record ReportReviewReq(
             @Schema(
-                            description = "리뷰 신고 사유를 입력해주세요.",
-                            allowableValues = {"UNRELATED", "PORNOGRAPHY", "PROFANITY"})
-                    @NotNull
+                            description = "리뷰 신고 사유를 입력해주세요.")
+                    @NotNull(message = "리뷰 신고 사유를 입력해주세요.")
                     ReportReason reason) {}
 }

--- a/src/main/java/everymeal/server/report/dto/ReportDto.java
+++ b/src/main/java/everymeal/server/report/dto/ReportDto.java
@@ -8,8 +8,6 @@ import jakarta.validation.constraints.NotNull;
 public class ReportDto {
 
     public record ReportReviewReq(
-            @Schema(
-                            description = "리뷰 신고 사유를 입력해주세요.")
-                    @NotNull(message = "리뷰 신고 사유를 입력해주세요.")
+            @Schema(description = "리뷰 신고 사유를 입력해주세요.") @NotNull(message = "리뷰 신고 사유를 입력해주세요.")
                     ReportReason reason) {}
 }

--- a/src/main/java/everymeal/server/report/dto/ReportDto.java
+++ b/src/main/java/everymeal/server/report/dto/ReportDto.java
@@ -1,0 +1,16 @@
+package everymeal.server.report.dto;
+
+
+import everymeal.server.report.entity.ReportReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public class ReportDto {
+
+    public record ReportReviewReq(
+            @Schema(
+                            description = "리뷰 신고 사유를 입력해주세요.",
+                            allowableValues = {"UNRELATED", "PORNOGRAPHY", "PROFANITY"})
+                    @NotNull
+                    ReportReason reason) {}
+}

--- a/src/main/java/everymeal/server/report/entity/Report.java
+++ b/src/main/java/everymeal/server/report/entity/Report.java
@@ -1,0 +1,48 @@
+package everymeal.server.report.entity;
+
+
+import everymeal.server.global.entity.BaseEntity;
+import everymeal.server.review.entity.Review;
+import everymeal.server.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity(name = "reports")
+@Table
+@NoArgsConstructor
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Enumerated(value = EnumType.STRING)
+    private ReportReason reason;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_idx")
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_idx")
+    private Review review;
+
+    @Builder
+    public Report(ReportReason reason, User reporter, Review review) {
+        this.reason = reason;
+        this.reporter = reporter;
+        this.review = review;
+    }
+}

--- a/src/main/java/everymeal/server/report/entity/ReportReason.java
+++ b/src/main/java/everymeal/server/report/entity/ReportReason.java
@@ -1,0 +1,20 @@
+package everymeal.server.report.entity;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public enum ReportReason {
+    UNRELATED("해당 식당과 무관한 리뷰"),
+    PROFANITY("비속어 및 혐오 발언"),
+    PORNOGRAPHY("음란성 게시물"),
+    ETC("기타");
+
+    private String value;
+
+    ReportReason(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/everymeal/server/report/repository/ReportRepository.java
+++ b/src/main/java/everymeal/server/report/repository/ReportRepository.java
@@ -1,0 +1,17 @@
+package everymeal.server.report.repository;
+
+
+import everymeal.server.report.entity.Report;
+import java.util.Optional;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    @Query(
+            value =
+                    "select r from reports r where r.review.idx = :reviewIdx and r.reporter.idx = :userIdx")
+    Optional<Report> findByReviewIdxAndUserIdx(
+            @Param("reviewIdx") Long reviewIdx, @Param("userIdx") Long userIdx);
+}

--- a/src/main/java/everymeal/server/report/service/ReportCommServiceImpl.java
+++ b/src/main/java/everymeal/server/report/service/ReportCommServiceImpl.java
@@ -1,0 +1,26 @@
+package everymeal.server.report.service;
+
+
+import everymeal.server.report.entity.Report;
+import everymeal.server.report.repository.ReportRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportCommServiceImpl {
+
+    private final ReportRepository reportRepository;
+
+    @Transactional
+    public Report save(Report report) {
+        return reportRepository.save(report);
+    }
+
+    public Optional<Report> getReportOptionalEntity(Long reviewIdx, Long userIdx) {
+        return reportRepository.findByReviewIdxAndUserIdx(reviewIdx, userIdx);
+    }
+}

--- a/src/main/java/everymeal/server/report/service/ReportService.java
+++ b/src/main/java/everymeal/server/report/service/ReportService.java
@@ -1,0 +1,9 @@
+package everymeal.server.report.service;
+
+
+import everymeal.server.report.dto.ReportDto.ReportReviewReq;
+
+public interface ReportService {
+
+    Boolean reportReview(Long reviewIdx, ReportReviewReq request, Long userIdx);
+}

--- a/src/main/java/everymeal/server/report/service/ReportServiceImpl.java
+++ b/src/main/java/everymeal/server/report/service/ReportServiceImpl.java
@@ -1,0 +1,53 @@
+package everymeal.server.report.service;
+
+
+import everymeal.server.global.exception.ApplicationException;
+import everymeal.server.global.exception.ExceptionList;
+import everymeal.server.report.dto.ReportDto.ReportReviewReq;
+import everymeal.server.report.entity.Report;
+import everymeal.server.review.entity.Review;
+import everymeal.server.review.service.ReviewCommServiceImpl;
+import everymeal.server.user.entity.User;
+import everymeal.server.user.service.UserCommServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final ReviewCommServiceImpl reviewCommServiceImpl;
+    private final UserCommServiceImpl userCommServiceImpl;
+    private final ReportCommServiceImpl reportCommServiceImpl;
+
+    @Override
+    @Transactional
+    public Boolean reportReview(Long reviewIdx, ReportReviewReq request, Long userIdx) {
+        // 리뷰 조회
+        Review review = reviewCommServiceImpl.getReviewEntity(reviewIdx);
+        // 신고 유저 조회
+        User reportUser = userCommServiceImpl.getUserEntity(userIdx);
+        // 리뷰 작성 유저 조회
+        User reviewUser = review.getUser();
+        // 리뷰 작성 유저와 신고 유저가 같은지 확인
+        if (reviewUser.equals(reportUser)) {
+            throw new ApplicationException(ExceptionList.REPORT_REVIEW_SELF);
+        }
+        // 리뷰 신고 여부 확인
+        if (reportCommServiceImpl.getReportOptionalEntity(reviewIdx, userIdx).isPresent()) {
+            throw new ApplicationException(ExceptionList.REPORT_REVIEW_ALREADY);
+        }
+        // 리뷰 신고 저장
+        Report report =
+                Report.builder()
+                        .reporter(reportUser)
+                        .review(review)
+                        .reason(request.reason())
+                        .build();
+        reportCommServiceImpl.save(report);
+
+        return true;
+    }
+}

--- a/src/main/java/everymeal/server/review/dto/response/ReviewDto.java
+++ b/src/main/java/everymeal/server/review/dto/response/ReviewDto.java
@@ -12,6 +12,7 @@ public class ReviewDto {
     public record ReviewTodayGetRes(Long reviewIdx, String content) {}
 
     public static ReviewTodayGetRes of(Map<String, Object> resultMap) {
+        if (resultMap == null) return null;
         return new ReviewTodayGetRes(
                 (Long) resultMap.get("reviewIdx"), (String) resultMap.get("content"));
     }

--- a/src/main/java/everymeal/server/review/entity/Review.java
+++ b/src/main/java/everymeal/server/review/entity/Review.java
@@ -3,6 +3,7 @@ package everymeal.server.review.entity;
 
 import everymeal.server.global.entity.BaseEntity;
 import everymeal.server.meal.entity.Restaurant;
+import everymeal.server.report.entity.Report;
 import everymeal.server.store.entity.Store;
 import everymeal.server.user.entity.User;
 import jakarta.persistence.CascadeType;
@@ -64,6 +65,9 @@ public class Review extends BaseEntity {
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "review_idx")
     private List<Image> images = new ArrayList<>();
+
+    @OneToMany(cascade = CascadeType.ALL)
+    private Set<Report> reports = new HashSet<>();
 
     @Builder
     public Review(

--- a/src/main/java/everymeal/server/review/service/ReviewCommServiceImpl.java
+++ b/src/main/java/everymeal/server/review/service/ReviewCommServiceImpl.java
@@ -1,0 +1,72 @@
+package everymeal.server.review.service;
+
+
+import everymeal.server.global.exception.ApplicationException;
+import everymeal.server.global.exception.ExceptionList;
+import everymeal.server.review.dto.response.ReviewDto;
+import everymeal.server.review.dto.response.ReviewDto.ReviewPagingVOWithCnt;
+import everymeal.server.review.entity.Review;
+import everymeal.server.review.entity.ReviewMark;
+import everymeal.server.review.repository.ReviewMapper;
+import everymeal.server.review.repository.ReviewMarkRepository;
+import everymeal.server.review.repository.ReviewRepository;
+import everymeal.server.user.entity.User;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewCommServiceImpl {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewMarkRepository reviewMarkRepository;
+    private final ReviewMapper reviewMapper;
+
+    @Transactional
+    public Review save(Review review) {
+        return reviewRepository.save(review);
+    }
+
+    public Review getReviewEntity(Long reviewIdx) {
+        return reviewRepository
+                .findById(reviewIdx)
+                .orElseThrow(() -> new ApplicationException(ExceptionList.REVIEW_NOT_FOUND));
+    }
+
+    public Review getReviewEntity(Long reviewIdx, User user) {
+        return reviewRepository
+                .findByIdxAndUser(reviewIdx, user)
+                .orElseThrow(() -> new ApplicationException(ExceptionList.REVIEW_NOT_FOUND));
+    }
+
+    public Optional<Review> getReviewOptionalEntity(Long reviewIdx) {
+        return reviewRepository.findById(reviewIdx);
+    }
+
+    public ReviewPagingVOWithCnt getReviewPagingVOWithCnt(ReviewDto.ReviewQueryParam queryParam) {
+        return reviewRepository.getReview(queryParam);
+    }
+
+    public Optional<ReviewMark> getReviewMarkOptionalEntity(Long reviewIdx, Long userIdx) {
+        return reviewMarkRepository.findByReviewIdxAndUserIdx(reviewIdx, userIdx);
+    }
+
+    @Transactional
+    public void deleteReviewMark(ReviewMark reviewMark) {
+        reviewMarkRepository.delete(reviewMark);
+    }
+
+    public Map<String, Object> getTodayReviewEntityFromMapper(
+            Long restaurantIdx, String offeredAt) {
+        return reviewMapper.findTodayReview(restaurantIdx, offeredAt);
+    }
+
+    @Transactional
+    public Review saveAndFlush(Review review) {
+        return reviewRepository.saveAndFlush(review);
+    }
+}

--- a/src/main/java/everymeal/server/user/entity/User.java
+++ b/src/main/java/everymeal/server/user/entity/User.java
@@ -2,6 +2,7 @@ package everymeal.server.user.entity;
 
 
 import everymeal.server.global.entity.BaseEntity;
+import everymeal.server.report.entity.Report;
 import everymeal.server.review.entity.Review;
 import everymeal.server.review.entity.ReviewMark;
 import everymeal.server.university.entity.University;
@@ -56,6 +57,9 @@ public class User extends BaseEntity {
 
     @OneToOne(mappedBy = "user")
     private Withdrawal withdrawal;
+
+    @OneToMany(mappedBy = "reporter")
+    private Set<Report> reports = new HashSet<>();
 
     @Builder
     public User(String nickname, String email, String profileImgUrl, University university) {

--- a/src/main/java/everymeal/server/user/service/UserCommServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/UserCommServiceImpl.java
@@ -1,0 +1,50 @@
+package everymeal.server.user.service;
+
+
+import everymeal.server.global.exception.ApplicationException;
+import everymeal.server.global.exception.ExceptionList;
+import everymeal.server.user.entity.User;
+import everymeal.server.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserCommServiceImpl {
+
+    private final UserRepository userRepository;
+
+    public User getUserEntity(Long userIdx) {
+        return userRepository
+                .findById(userIdx)
+                .orElseThrow(() -> new ApplicationException(ExceptionList.USER_NOT_FOUND));
+    }
+
+    public Optional<User> getUserOptionalEntityByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    public User getUserEntityByEmail(String email) {
+        return userRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new ApplicationException(ExceptionList.USER_NOT_FOUND));
+    }
+
+    public Optional<User> getUserOptionalEntityByNickname(String nickname) {
+        return userRepository.findByNickname(nickname);
+    }
+
+    public User getUserEntityByNickname(String nickname) {
+        return userRepository
+                .findByNickname(nickname)
+                .orElseThrow(() -> new ApplicationException(ExceptionList.USER_NOT_FOUND));
+    }
+
+    @Transactional
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/everymeal/server/user/service/UserCommServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/UserCommServiceImpl.java
@@ -37,12 +37,6 @@ public class UserCommServiceImpl {
         return userRepository.findByNickname(nickname);
     }
 
-    public User getUserEntityByNickname(String nickname) {
-        return userRepository
-                .findByNickname(nickname)
-                .orElseThrow(() -> new ApplicationException(ExceptionList.USER_NOT_FOUND));
-    }
-
     @Transactional
     public User save(User user) {
         return userRepository.save(user);

--- a/src/main/java/everymeal/server/user/service/WithdrawalServiceImpl.java
+++ b/src/main/java/everymeal/server/user/service/WithdrawalServiceImpl.java
@@ -1,0 +1,21 @@
+package everymeal.server.user.service;
+
+
+import everymeal.server.user.entity.Withdrawal;
+import everymeal.server.user.repository.WithdrawalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WithdrawalServiceImpl {
+
+    private final WithdrawalRepository withdrawalRepository;
+
+    @Transactional
+    public void save(Withdrawal withdrawal) {
+        withdrawalRepository.save(withdrawal);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ springdoc:
   api-docs:
     groups:
       enabled: true
-    enabled: true
+#    enabled: true
 
 mybatis:
   type-aliases-package: everymeal.server

--- a/src/main/resources/mybatis/mappers/MealMapper.xml
+++ b/src/main/resources/mybatis/mappers/MealMapper.xml
@@ -34,40 +34,6 @@
     ORDER BY r.name ASC, operatingTime ASC
   </select>
 
-  <select id="findWeekList">
-    SELECT
-    COALESCE(m.idx, 0) AS mealIdx,
-    CONCAT(#{date}, ' ', SUBSTRING(m.offered_at, 12, 5)) AS offeredAt,
-    COALESCE(m.meal_status, 'OPEN') AS mealStatus,
-    meal_types.mealType,
-    CASE WHEN r.is_open_breakfast = true AND meal_types.mealType = 'BREAKFAST' THEN CONCAT(SUBSTRING(r.breakfast_start_time, 1, 5), '-', SUBSTRING(r.breakfast_end_time, 1, 5))
-    WHEN r.is_open_lunch = true AND meal_types.mealType = 'LUNCH' THEN CONCAT(SUBSTRING(r.lunch_start_time, 1, 5), '-', SUBSTRING(r.lunch_end_time, 1, 5))
-    WHEN r.is_open_dinner = true AND meal_types.mealType = 'DINNER' THEN CONCAT(SUBSTRING(r.dinner_start_time, 1, 5), '-', SUBSTRING(r.dinner_end_time, 1, 5))
-    ELSE '운영시간이 아닙니다'
-    END AS operatingTime,
-    COALESCE(m.menu, '등록된 식단이 없습니다.') AS menu,
-    COALESCE(m.price, 0) AS price,
-    COALESCE(m.category, 'DEFAULT') AS category,
-    r.idx AS restaurantIdx,
-    r.name AS restaurantName,
-    CONCAT(u.name, ' ', u.campus_name) AS universityName,
-    r.review_count AS reviewCount,
-    r.grade AS grade
-    FROM restaurant r
-    JOIN (SELECT DISTINCT meal_type AS mealType FROM meal) AS meal_types ON 1=1
-    LEFT JOIN meal m ON m.restaurant_idx = r.idx AND m.meal_type = meal_types.mealType AND m.offered_at = CONCAT(#{date}, ' ', SUBSTRING(m.offered_at, 12, 5))
-    INNER JOIN university u ON r.university_idx = u.idx AND u.is_deleted = false
-    WHERE
-    u.name = #{universityName} AND u.campus_name = #{campusName}
-    AND (
-    <foreach item="date" collection="weeklyDates" open="" separator="" close="">
-    (meal_types.mealType = 'BREAKFAST' AND r.is_open_breakfast = true AND m.offered_at = DATE(#{date}) ) OR
-    (meal_types.mealType = 'LUNCH' AND r.is_open_lunch = true AND m.offered_at = DATE(#{date})) OR
-    (meal_types.mealType = 'DINNER' AND r.is_open_dinner = true AND m.offered_at = DATE(#{date}))
-    </foreach>
-    )
-    ORDER BY r.name ASC, operatingTime ASC
-  </select>
 
   <select id="findAllByOfferedAtOnDateAndMealType">
     SELECT *

--- a/src/main/resources/mybatis/mappers/ReviewMapper.xml
+++ b/src/main/resources/mybatis/mappers/ReviewMapper.xml
@@ -8,7 +8,7 @@
            JOIN restaurant r2 ON r.restaurant_idx = r2.idx AND r2.idx = #{restaurantIdx}
     WHERE DATE(r.created_at) = DATE(#{offeredAt})
       AND r.is_today_review = 1
-      AND r.idx = (
+      OR r.idx = (
       SELECT rm.review_idx
       FROM review_marks rm
       JOIN reviews r ON rm.review_idx = r.idx

--- a/src/main/resources/mybatis/mappers/ReviewMapper.xml
+++ b/src/main/resources/mybatis/mappers/ReviewMapper.xml
@@ -5,7 +5,6 @@
     SELECT r.idx as 'reviewIdx',
            r.content as 'content'
     FROM reviews r
-           LEFT JOIN meal m ON r.meal_idx = m.idx
            JOIN restaurant r2 ON r.restaurant_idx = r2.idx AND r2.idx = #{restaurantIdx}
     WHERE DATE(r.created_at) = DATE(#{offeredAt})
       AND r.is_today_review = 1
@@ -13,6 +12,7 @@
       SELECT rm.review_idx
       FROM review_marks rm
       JOIN reviews r ON rm.review_idx = r.idx
+      WHERE DATE(r.created_at) = DATE(#{offeredAt})
       GROUP BY rm.review_idx
       ORDER BY COUNT(rm.review_idx) DESC
       LIMIT 1

--- a/src/test/java/everymeal/server/global/ControllerTestSupport.java
+++ b/src/test/java/everymeal/server/global/ControllerTestSupport.java
@@ -7,6 +7,8 @@ import everymeal.server.global.util.authresolver.UserJwtResolver;
 import everymeal.server.infra.HealthCheckController;
 import everymeal.server.meal.controller.MealController;
 import everymeal.server.meal.service.MealService;
+import everymeal.server.report.controller.ReportController;
+import everymeal.server.report.service.ReportService;
 import everymeal.server.review.controller.ReviewController;
 import everymeal.server.review.service.ReviewService;
 import everymeal.server.store.controller.StoreController;
@@ -27,7 +29,8 @@ import org.springframework.test.web.servlet.MockMvc;
             UniversityController.class,
             HealthCheckController.class,
             StoreController.class,
-            ReviewController.class
+            ReviewController.class,
+            ReportController.class
         })
 public abstract class ControllerTestSupport {
 
@@ -48,4 +51,6 @@ public abstract class ControllerTestSupport {
     @MockBean protected UniversityService universityService;
 
     @MockBean protected ReviewService reviewService;
+
+    @MockBean protected ReportService reportService;
 }

--- a/src/test/java/everymeal/server/meal/MealData.java
+++ b/src/test/java/everymeal/server/meal/MealData.java
@@ -72,8 +72,8 @@ public class MealData {
         return new RestaurantRegisterReq(
                 "명지대학교",
                 "인문캠퍼스",
-                "address",
-                "phoneNumber",
+                "서울시 서대문구 거북골로 34",
+                "MCC 식당",
                 LocalTime.of(8, 0),
                 LocalTime.of(10, 30),
                 LocalTime.of(11, 0),

--- a/src/test/java/everymeal/server/report/controller/ReportControllerTest.java
+++ b/src/test/java/everymeal/server/report/controller/ReportControllerTest.java
@@ -1,0 +1,53 @@
+package everymeal.server.report.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import everymeal.server.global.ControllerTestSupport;
+import everymeal.server.global.util.authresolver.UserJwtResolver;
+import everymeal.server.global.util.authresolver.entity.AuthenticatedUser;
+import everymeal.server.report.dto.ReportDto;
+import everymeal.server.report.dto.ReportDto.ReportReviewReq;
+import everymeal.server.report.entity.ReportReason;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+class ReportControllerTest extends ControllerTestSupport {
+
+    @MockBean UserJwtResolver userJwtResolver;
+
+    @Test
+    void 식당리뷰_신고하기() throws Exception {
+        // given
+        ReportDto.ReportReviewReq req = new ReportReviewReq(ReportReason.UNRELATED);
+
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
+
+        // when-then
+        mockMvc.perform(
+                        post("/api/v1/reports/review/{reveiwIdx}", 1L)
+                                .content(objectMapper.writeValueAsString(req))
+                                .contentType("application/json"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 식당리뷰_신고하기_신고이유_없음() throws Exception {
+        // given
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
+
+        // when-then
+        mockMvc.perform(
+                        post("/api/v1/reports/review/{reveiwIdx}", 1L)
+                                .contentType("application/json"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/everymeal/server/report/service/ReportServiceImplTest.java
+++ b/src/test/java/everymeal/server/report/service/ReportServiceImplTest.java
@@ -1,0 +1,131 @@
+package everymeal.server.report.service;
+
+import static everymeal.server.meal.MealData.getRestaurant;
+import static everymeal.server.meal.MealData.getRestaurantRegisterReq;
+import static everymeal.server.meal.MealData.getUniversity;
+import static everymeal.server.review.ReviewData.getReviewEntity;
+import static everymeal.server.review.ReviewData.getUserEntity;
+import static org.junit.jupiter.api.Assertions.*;
+
+import everymeal.server.global.IntegrationTestSupport;
+import everymeal.server.global.exception.ApplicationException;
+import everymeal.server.global.exception.ExceptionList;
+import everymeal.server.meal.entity.Restaurant;
+import everymeal.server.meal.repository.RestaurantRepository;
+import everymeal.server.report.dto.ReportDto;
+import everymeal.server.report.dto.ReportDto.ReportReviewReq;
+import everymeal.server.report.entity.Report;
+import everymeal.server.report.entity.ReportReason;
+import everymeal.server.report.repository.ReportRepository;
+import everymeal.server.review.entity.Review;
+import everymeal.server.review.repository.ReviewRepository;
+import everymeal.server.university.entity.University;
+import everymeal.server.university.repository.UniversityRepository;
+import everymeal.server.user.entity.User;
+import everymeal.server.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ReportServiceImplTest extends IntegrationTestSupport {
+
+    @Autowired private ReportService reportService;
+
+    @Autowired private ReportRepository reportRepository;
+
+    @Autowired private UserRepository userRepository;
+
+    @Autowired private RestaurantRepository restaurantRepository;
+
+    @Autowired private UniversityRepository universityRepository;
+
+    @Autowired private ReviewRepository reviewRepository;
+
+    private University university;
+    private Restaurant restaurant;
+    private User reporter;
+    private User reportedUser;
+    private Review review;
+
+    @BeforeEach
+    void setUp() {
+        university = universityRepository.save(getUniversity());
+        restaurant =
+                restaurantRepository.save(getRestaurant(university, getRestaurantRegisterReq()));
+        reporter = userRepository.save(getUserEntity(university, 1));
+        reportedUser = userRepository.save(getUserEntity(university, 2));
+        review = reviewRepository.save(getReviewEntity(restaurant, reportedUser));
+    }
+
+    @AfterEach
+    void tearDown() {
+        reportRepository.deleteAllInBatch();
+        reviewRepository.deleteAllInBatch();
+        restaurantRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        universityRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 학생식당리뷰_신고하기_자기_자신리뷰() throws Exception {
+        // given
+        ReportDto.ReportReviewReq request = new ReportReviewReq(ReportReason.UNRELATED);
+        // when
+        ApplicationException exception =
+                assertThrows(
+                        ApplicationException.class,
+                        () -> {
+                            reportService.reportReview(
+                                    review.getIdx(), request, reportedUser.getIdx());
+                        });
+        // then
+        assertEquals(exception.getErrorCode(), ExceptionList.REPORT_REVIEW_SELF.CODE);
+    }
+
+    @Test
+    void 학생식당리뷰_신고하기() throws Exception {
+        // given
+        ReportDto.ReportReviewReq request = new ReportReviewReq(ReportReason.UNRELATED);
+        // when
+        Boolean result = reportService.reportReview(review.getIdx(), request, reporter.getIdx());
+        Report report =
+                reportRepository
+                        .findByReviewIdxAndUserIdx(review.getIdx(), reporter.getIdx())
+                        .get();
+        // then
+        assertTrue(result);
+        assertEquals(report.getReason(), request.reason());
+    }
+
+    @Test
+    void 학생식당리뷰_신고하기_이미_신고한_리뷰() throws Exception {
+        // given
+        ReportDto.ReportReviewReq request = new ReportReviewReq(ReportReason.UNRELATED);
+        reportService.reportReview(review.getIdx(), request, reporter.getIdx());
+        // when
+        ApplicationException exception =
+                assertThrows(
+                        ApplicationException.class,
+                        () -> {
+                            reportService.reportReview(review.getIdx(), request, reporter.getIdx());
+                        });
+        // then
+        assertEquals(exception.getErrorCode(), ExceptionList.REPORT_REVIEW_ALREADY.CODE);
+    }
+
+    @Test
+    void 학생식당리뷰_신고하기_없는_리뷰() throws Exception {
+        // given
+        ReportDto.ReportReviewReq request = new ReportReviewReq(ReportReason.UNRELATED);
+        // when
+        ApplicationException exception =
+                assertThrows(
+                        ApplicationException.class,
+                        () -> {
+                            reportService.reportReview(0L, request, reporter.getIdx());
+                        });
+        // then
+        assertEquals(exception.getErrorCode(), ExceptionList.REVIEW_NOT_FOUND.CODE);
+    }
+}

--- a/src/test/java/everymeal/server/review/ReviewData.java
+++ b/src/test/java/everymeal/server/review/ReviewData.java
@@ -41,13 +41,16 @@ public class ReviewData {
     }
 
     public static Review getReviewEntity(Restaurant restaurant, User user) {
-        return Review.builder()
-                .restaurant(restaurant)
-                .grade(1)
-                .images(List.of())
-                .content("리뷰 내용")
-                .user(user)
-                .build();
+        Review review =
+                Review.builder()
+                        .restaurant(restaurant)
+                        .grade(1)
+                        .images(List.of())
+                        .content("리뷰 내용")
+                        .user(user)
+                        .build();
+        review.updateTodayReview(true);
+        return review;
     }
 
     public static ReviewGetRes getReviewGetRes() {

--- a/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
@@ -221,7 +221,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
         // given
         Review review = getReviewEntity(restaurant, user);
         review.updateTodayReview(true);
-        Review saved = reviewRepository.save(review);
+        Review saved = reviewRepository.saveAndFlush(review);
         saved.addMark(user);
         reviewRepository.saveAndFlush(saved);
 

--- a/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
@@ -219,16 +219,13 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
     @Test
     void getTodayReview() {
         // given
-        Review review = getReviewEntity(restaurant, user);
-        review.updateTodayReview(true);
-        Review saved = reviewRepository.saveAndFlush(review);
-        saved.addMark(user);
-        reviewRepository.saveAndFlush(saved);
+        review.addMark(user);
+        reviewRepository.saveAndFlush(review);
 
         String offeredAt = LocalDate.now().toString();
         // when
         var result = reviewService.getTodayReview(restaurant.getIdx(), offeredAt);
         // then
-        assertThat(result).isNotNull();
+        assertEquals(result.content(), review.getContent());
     }
 }


### PR DESCRIPTION
## 작업 내용
식당 리뷰 신고하기 기능 개발 및 코드 리펙토링을 진행했습니다.

## 관련 이슈
#75 

## 작업 확인 방법
Swagger-ui

## 추가 정보 (선택 사항)

1. 리뷰 신고하기 정책이 궁금해요.

case 1) 신고 접수 -> 즉시 삭제 처리
case 2) 신고 접수 -> 관리자가 삭제 처리

후자의 경우, 백오피스가 필요할 것으로 생각됩니다.
정책에 따라 신고 테이블(reports)는 변경될 수 있습니다. ( 이를 위해 최소한의 데이터만을 정의해두었습니다. )

2. swagger-ui 접근 제한을 위해 application.yml 파일에서 swagger 설정을 변경했습니다. 
prod 환경에서 swagger 접근으로 무분별하게 디비 접근을 할 수 없도록 사전에 방지하는 것이 좋을 거 같다는 생각에 변경했습니다.

3. 서비스 계층 리펙토링

기존 : 하나의 서비스에 여러 repository를 접근
변경 : 하나의 repository에 접근할 수 있는 통로는 단 한군데.

하나의 테이블에 접근할 수 있는 통로를 한 군데만 두어 코드의 유지보수성을 높이고, 높은 의존 관계를 낮추는 작업을 수행했습니다.
`**commServiceImpl` 가 붙은 클래스가 repository를 갖는 서비스입니다.
이외에 기존 컨벤션 규칙에 따른 `**ServiceImpl`은 비즈니스 로직을 수행하는 서비스입니다.

4. ExceptionList 내 errorCode의 prefix 변경

기존 : 도메인의 시작 키워드 + 000 + i ( 예: U0001 -> 유저 관련 )
변경 : 도메인 키워드 축약어 + 000 + i ( 예: USR001 -> 유저 관련 ) USR ... USER 

변경 이유 : 겹치는 대문자가 생기면 이를 구분하기가 어렵다고 생각되어 prefix를 전체적으로 변경하였습니다.