### PR TITLE
Path 관련 ERROR 정의

### DIFF
--- a/src/main/java/everymeal/server/global/exception/ExceptionList.java
+++ b/src/main/java/everymeal/server/global/exception/ExceptionList.java
@@ -35,6 +35,10 @@ public enum ExceptionList {
     REPORT_ALREADY_EXIST("RPT0002", HttpStatus.CONFLICT, "이미 신고한 리뷰입니다."),
     REPORT_REVIEW_SELF("RPT0003", HttpStatus.FORBIDDEN, "자신의 리뷰를 신고할 수 없습니다."),
     REPORT_REVIEW_ALREADY("RPT0004", HttpStatus.CONFLICT, "이미 신고한 리뷰입니다."),
+
+    // SERVER
+    SERVER_ERROR("SRV0001", HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생하였습니다."),
+    PATH_NOT_FOUND("SRV0002", HttpStatus.NOT_FOUND, "요청한 경로가 존재하지 않습니다."),
     ;
 
     public final String CODE;

--- a/src/main/java/everymeal/server/global/exception/controller/ExceptionController.java
+++ b/src/main/java/everymeal/server/global/exception/controller/ExceptionController.java
@@ -1,0 +1,17 @@
+package everymeal.server.global.exception.controller;
+
+import static everymeal.server.global.exception.ExceptionList.PATH_NOT_FOUND;
+
+import everymeal.server.global.exception.ApplicationException;
+import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ExceptionController implements ErrorController {
+
+    @GetMapping("/error")
+    public String error() {
+        throw new ApplicationException(PATH_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 작업 내용
새로운 예외 항목과 관련된 코드를 추가했습니다.
ExceptionList에 SERVER_ERROR와 PATH_NOT_FOUND 예외를 추가했습니다.
ExceptionController를 작성하여 /error 엔드포인트에서 PATH_NOT_FOUND 예외를 던지도록 했습니다.

## 관련 이슈
/error 엔드포인트를 호출하여 PATH_NOT_FOUND 예외가 발생하는지 확인할 수 있습니다.
테스트 코드를 실행하여 예외가 적절히 처리되는지 확인할 수 있습니다.

## 작업 확인 방법
ExceptionList에 SERVER_ERROR와 PATH_NOT_FOUND 예외 추가
ExceptionController 클래스 추가하여 /error 엔드포인트에서 PATH_NOT_FOUND 예외 던지도록 설정
