### PR TITLE
[feature/store-post-review] 식당 리뷰 생성 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 	implementation 'org.hibernate.orm:hibernate-core:6.2.5.Final'
 
 	//QueryDSL
-	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+//	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 	implementation 'org.hibernate.orm:hibernate-core:6.2.5.Final'
 
 	//QueryDSL
-//	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/everymeal/server/meal/controller/dto/response/DayMealGetRes.java
+++ b/src/main/java/everymeal/server/meal/controller/dto/response/DayMealGetRes.java
@@ -32,7 +32,7 @@ public record DayMealGetRes(
                                         (String) meal.get("menu"),
                                         (Double) meal.get("price"),
                                         (String) meal.get("category"),
-                                        (Long) meal.get("restaurantIdx"),
+                                        (Long) meal.get("idx"),
                                         (String) meal.get("restaurantName"),
                                         (String) meal.get("universityName"),
                                         (Integer) meal.get("reviewCount"),

--- a/src/main/java/everymeal/server/review/controller/ReviewController.java
+++ b/src/main/java/everymeal/server/review/controller/ReviewController.java
@@ -41,13 +41,13 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @Operation(
-            summary = "식당 리뷰 작성",
+            summary = "학식 리뷰 작성",
             description = """
-  식당 리뷰 작성을 진행합니다. <br>
+  학식 리뷰 작성을 진행합니다. <br>
   로그인이 필요한 기능입니다.
   """)
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "리뷰 등록 성공"),
+        @ApiResponse(responseCode = "200", description = "학식 리뷰 등록 성공"),
     })
     @Auth(require = true)
     @PostMapping
@@ -188,5 +188,23 @@ public class ReviewController {
                     @Schema(description = "조회하고자 하는 날짜 ( yyyy-MM-dd )", defaultValue = "2023-10-01")
                     String offeredAt) {
         return ApplicationResponse.ok(reviewService.getTodayReview(restaurantIdx, offeredAt));
+    }
+
+    @Auth(require = true)
+    @Operation(summary = "주변 식당 리뷰 생성", description = """
+    주변 식당 리뷰 생성합니다. <br>
+    """)
+    @SecurityRequirement(name = "jwt-user-auth")
+    @ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "리뷰 생성 성공",
+                content = @Content(schema = @Schema(implementation = Long.class))),
+    })
+    @PostMapping("/store")
+    public ApplicationResponse<Long> createReviewByStore(
+            @RequestBody ReviewCreateReq request,
+            @Parameter(hidden = true) @AuthUser AuthenticatedUser user) {
+        return ApplicationResponse.ok(reviewService.createReviewByStore(request, user.getIdx()));
     }
 }

--- a/src/main/java/everymeal/server/review/dto/request/ReviewCreateReq.java
+++ b/src/main/java/everymeal/server/review/dto/request/ReviewCreateReq.java
@@ -21,10 +21,7 @@ public record ReviewCreateReq(
                         defaultValue = "오늘 학식 진짜 미침...안먹으면 땅을 치고 후회함")
                 @Nullable
                 String content,
-        @Schema(
-                        description =
-                                "학식이 보이는 사진 이미지 주소를 String 리스트 형태로 입력해주세요. 최대 10개의 이미지를 첨부할 수 있습니다."
-        )
+        @Schema(description = "학식이 보이는 사진 이미지 주소를 String 리스트 형태로 입력해주세요. 최대 10개의 이미지를 첨부할 수 있습니다.")
                 @Max(10)
                 List<String> imageList,
         @Schema(

--- a/src/main/java/everymeal/server/review/dto/request/ReviewCreateReq.java
+++ b/src/main/java/everymeal/server/review/dto/request/ReviewCreateReq.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public record ReviewCreateReq(
         @Schema(description = "리뷰를 남기고자 하는 식당의 idx를 입력해주세요.", defaultValue = "1") @NotBlank
-                Long restaurantIdx,
+                Long idx,
         @Schema(
                         description =
                                 "학식에 대한 리뷰 평가 점수를 정수형 최소 1 ~ 최대 5점까지로 입력해주세요. 사진 리뷰인 경우 0으로 보내주세요.",
@@ -23,8 +23,8 @@ public record ReviewCreateReq(
                 String content,
         @Schema(
                         description =
-                                "학식이 보이는 사진 이미지 주소를 String 리스트 형태로 입력해주세요. 최대 10개의 이미지를 첨부할 수 있습니다.",
-                        defaultValue = "['이미지 주소']")
+                                "학식이 보이는 사진 이미지 주소를 String 리스트 형태로 입력해주세요. 최대 10개의 이미지를 첨부할 수 있습니다."
+        )
                 @Max(10)
                 List<String> imageList,
         @Schema(

--- a/src/main/java/everymeal/server/review/service/ReviewCommServiceImpl.java
+++ b/src/main/java/everymeal/server/review/service/ReviewCommServiceImpl.java
@@ -62,7 +62,9 @@ public class ReviewCommServiceImpl {
 
     public Map<String, Object> getTodayReviewEntityFromMapper(
             Long restaurantIdx, String offeredAt) {
-        return reviewMapper.findTodayReview(restaurantIdx, offeredAt);
+        Map<String, Object> todayReview = reviewMapper.findTodayReview(restaurantIdx, offeredAt);
+        System.out.println("todayReview = " + todayReview);
+        return todayReview;
     }
 
     @Transactional

--- a/src/main/java/everymeal/server/review/service/ReviewService.java
+++ b/src/main/java/everymeal/server/review/service/ReviewService.java
@@ -18,4 +18,6 @@ public interface ReviewService {
     Boolean markReview(Long reviewIdx, boolean isLike, Long userIdx);
 
     ReviewTodayGetRes getTodayReview(Long restaurantIdx, String offeredAt);
+
+    Long createReviewByStore(ReviewCreateReq request, Long idx);
 }

--- a/src/main/java/everymeal/server/review/service/ReviewServiceImpl.java
+++ b/src/main/java/everymeal/server/review/service/ReviewServiceImpl.java
@@ -172,9 +172,7 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public ReviewTodayGetRes getTodayReview(Long restaurantIdx, String offeredAt) {
-        Map<String, Object> todayReviewEntityFromMapper =
-                reviewCommServiceImpl.getTodayReviewEntityFromMapper(restaurantIdx, offeredAt);
-        return ReviewDto.of(todayReviewEntityFromMapper);
+        return ReviewDto.of(reviewCommServiceImpl.getTodayReviewEntityFromMapper(restaurantIdx, offeredAt));
     }
 
     @Override

--- a/src/main/java/everymeal/server/review/service/ReviewServiceImpl.java
+++ b/src/main/java/everymeal/server/review/service/ReviewServiceImpl.java
@@ -172,10 +172,9 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public ReviewTodayGetRes getTodayReview(Long restaurantIdx, String offeredAt) {
-        Map<String, Object> todayReviewEntityFromMapper = reviewCommServiceImpl.getTodayReviewEntityFromMapper(
-            restaurantIdx, offeredAt);
-        return ReviewDto.of(
-            todayReviewEntityFromMapper);
+        Map<String, Object> todayReviewEntityFromMapper =
+                reviewCommServiceImpl.getTodayReviewEntityFromMapper(restaurantIdx, offeredAt);
+        return ReviewDto.of(todayReviewEntityFromMapper);
     }
 
     @Override

--- a/src/main/java/everymeal/server/review/service/ReviewServiceImpl.java
+++ b/src/main/java/everymeal/server/review/service/ReviewServiceImpl.java
@@ -3,6 +3,7 @@ package everymeal.server.review.service;
 import static everymeal.server.global.exception.ExceptionList.REVIEW_ALREADY_MARKED;
 import static everymeal.server.global.exception.ExceptionList.REVIEW_MARK_NOT_FOUND;
 import static everymeal.server.global.exception.ExceptionList.REVIEW_UNAUTHORIZED;
+import static everymeal.server.global.exception.ExceptionList.STORE_NOT_FOUND;
 
 import everymeal.server.global.exception.ApplicationException;
 import everymeal.server.global.util.TimeFormatUtil;
@@ -15,10 +16,13 @@ import everymeal.server.review.dto.response.ReviewDto.ReviewPaging;
 import everymeal.server.review.dto.response.ReviewDto.ReviewTodayGetRes;
 import everymeal.server.review.entity.Image;
 import everymeal.server.review.entity.Review;
+import everymeal.server.store.entity.Store;
+import everymeal.server.store.repository.StoreRepository;
 import everymeal.server.user.entity.User;
 import everymeal.server.user.service.UserCommServiceImpl;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,13 +35,13 @@ public class ReviewServiceImpl implements ReviewService {
     private final RestaurantCommServiceImpl restaurantCommServiceImpl;
     private final UserCommServiceImpl userCommServiceImpl;
     private final ReviewCommServiceImpl reviewCommServiceImpl;
+    private final StoreRepository storeRepository;
 
     @Override
     @Transactional
     public Long createReview(ReviewCreateReq request, Long userIdx) {
         // (1) restaurant 객체 조회
-        Restaurant restaurant =
-                restaurantCommServiceImpl.getRestaurantEntity(request.restaurantIdx());
+        Restaurant restaurant = restaurantCommServiceImpl.getRestaurantEntity(request.idx());
 
         // (2) 이미지 주소 <> 이미지 객체 치환
         List<Image> imageList = getImageFromString(request.imageList());
@@ -168,8 +172,42 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public ReviewTodayGetRes getTodayReview(Long restaurantIdx, String offeredAt) {
+        Map<String, Object> todayReviewEntityFromMapper = reviewCommServiceImpl.getTodayReviewEntityFromMapper(
+            restaurantIdx, offeredAt);
         return ReviewDto.of(
-                reviewCommServiceImpl.getTodayReviewEntityFromMapper(restaurantIdx, offeredAt));
+            todayReviewEntityFromMapper);
+    }
+
+    @Override
+    @Transactional
+    public Long createReviewByStore(ReviewCreateReq request, Long userIdx) {
+        // (1) restaurant 객체 조회
+        Store store =
+                storeRepository
+                        .findById(request.idx())
+                        .orElseThrow(() -> new ApplicationException(STORE_NOT_FOUND));
+
+        // (2) 이미지 주소 <> 이미지 객체 치환
+        List<Image> imageList = getImageFromString(request.imageList());
+        User user = userCommServiceImpl.getUserEntity(userIdx);
+
+        // (3) Entity 생성 ( 사진리뷰인지 분기 처리 )
+        Review review =
+                (request.content() == null && request.grade() == 0)
+                        ? Review.builder().images(imageList).store(store).user(user).build()
+                        : Review.builder()
+                                .content(request.content())
+                                .images(imageList)
+                                .store(store)
+                                .grade(request.grade())
+                                .user(user)
+                                .build();
+
+        // (4) 저장
+        Review savedReview = reviewCommServiceImpl.save(review);
+
+        store.addGrade(request.grade());
+        return savedReview.getIdx();
     }
 
     /**

--- a/src/main/java/everymeal/server/review/service/ReviewServiceImpl.java
+++ b/src/main/java/everymeal/server/review/service/ReviewServiceImpl.java
@@ -22,7 +22,6 @@ import everymeal.server.user.entity.User;
 import everymeal.server.user.service.UserCommServiceImpl;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -172,7 +171,8 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public ReviewTodayGetRes getTodayReview(Long restaurantIdx, String offeredAt) {
-        return ReviewDto.of(reviewCommServiceImpl.getTodayReviewEntityFromMapper(restaurantIdx, offeredAt));
+        return ReviewDto.of(
+                reviewCommServiceImpl.getTodayReviewEntityFromMapper(restaurantIdx, offeredAt));
     }
 
     @Override

--- a/src/main/java/everymeal/server/store/entity/Store.java
+++ b/src/main/java/everymeal/server/store/entity/Store.java
@@ -94,4 +94,8 @@ public class Store extends BaseEntity {
         this.university = university;
         this.isDeleted = Boolean.FALSE;
     }
+
+    public void addGrade(Integer grade) {
+        this.gradeStatistics.addGrade(grade);
+    }
 }

--- a/src/main/resources/mybatis/mappers/ReviewMapper.xml
+++ b/src/main/resources/mybatis/mappers/ReviewMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="everymeal.server.review.repository.ReviewMapper">
-  <select id="findTodayReview">
+  <select id="findTodayReview" resultType="java.util.Map">
     SELECT r.idx as 'reviewIdx',
            r.content as 'content'
     FROM reviews r

--- a/src/test/java/everymeal/server/review/ReviewData.java
+++ b/src/test/java/everymeal/server/review/ReviewData.java
@@ -34,21 +34,21 @@ public class ReviewData {
 
     public static Store getStoreEntity(University university) {
         return Store.builder()
-            .name("name")
-            .address("address")
-            .categoryGroup("categoryGroup")
-            .category("category")
-            .kakaoId("kakaoId")
-            .phone("phone")
-            .distance(3)
-            .url("url")
-            .roadAddress("roadAddress")
-            .x("x")
-            .y("y")
-            .gradeStatistics(new GradeStatistics())
-            .university(university)
-            .categoryDetail("한식")
-            .build();
+                .name("name")
+                .address("address")
+                .categoryGroup("categoryGroup")
+                .category("category")
+                .kakaoId("kakaoId")
+                .phone("phone")
+                .distance(3)
+                .url("url")
+                .roadAddress("roadAddress")
+                .x("x")
+                .y("y")
+                .gradeStatistics(new GradeStatistics())
+                .university(university)
+                .categoryDetail("한식")
+                .build();
     }
 
     public static Review getReviewEntity() {

--- a/src/test/java/everymeal/server/review/ReviewData.java
+++ b/src/test/java/everymeal/server/review/ReviewData.java
@@ -8,6 +8,8 @@ import everymeal.server.review.dto.response.ReviewDto.ReviewGetRes;
 import everymeal.server.review.dto.response.ReviewDto.ReviewPaging;
 import everymeal.server.review.dto.response.ReviewDto.ReviewPagingVOWithCnt;
 import everymeal.server.review.entity.Review;
+import everymeal.server.store.entity.GradeStatistics;
+import everymeal.server.store.entity.Store;
 import everymeal.server.university.entity.University;
 import everymeal.server.user.entity.User;
 import java.util.List;
@@ -28,6 +30,25 @@ public class ReviewData {
 
     public static User getUserEntity(University university, int i) {
         return new User("test" + i, "test" + i + "@everymeal.com", "test_IMG_URL", university);
+    }
+
+    public static Store getStoreEntity(University university) {
+        return Store.builder()
+            .name("name")
+            .address("address")
+            .categoryGroup("categoryGroup")
+            .category("category")
+            .kakaoId("kakaoId")
+            .phone("phone")
+            .distance(3)
+            .url("url")
+            .roadAddress("roadAddress")
+            .x("x")
+            .y("y")
+            .gradeStatistics(new GradeStatistics())
+            .university(university)
+            .categoryDetail("한식")
+            .build();
     }
 
     public static Review getReviewEntity() {

--- a/src/test/java/everymeal/server/review/controller/ReviewControllerTest.java
+++ b/src/test/java/everymeal/server/review/controller/ReviewControllerTest.java
@@ -177,4 +177,20 @@ class ReviewControllerTest extends ControllerTestSupport {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk());
     }
+
+    @DisplayName("주변 식당 리뷰 생성")
+    @Test
+    void createReviewAround() throws Exception {
+        // given
+        ReviewCreateReq req = new ReviewCreateReq(1L, 5, "오늘 학식 진짜 미침", List.of(), true);
+        given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
+            .willReturn(AuthenticatedUser.builder().idx(1L).build());
+        // when-then
+        mockMvc.perform(
+                post("/api/v1/reviews/store")
+                    .content(objectMapper.writeValueAsString(req))
+                    .contentType(MediaType.APPLICATION_JSON))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/everymeal/server/review/controller/ReviewControllerTest.java
+++ b/src/test/java/everymeal/server/review/controller/ReviewControllerTest.java
@@ -184,13 +184,13 @@ class ReviewControllerTest extends ControllerTestSupport {
         // given
         ReviewCreateReq req = new ReviewCreateReq(1L, 5, "오늘 학식 진짜 미침", List.of(), true);
         given(userJwtResolver.resolveArgument(any(), any(), any(), any()))
-            .willReturn(AuthenticatedUser.builder().idx(1L).build());
+                .willReturn(AuthenticatedUser.builder().idx(1L).build());
         // when-then
         mockMvc.perform(
-                post("/api/v1/reviews/store")
-                    .content(objectMapper.writeValueAsString(req))
-                    .contentType(MediaType.APPLICATION_JSON))
-            .andDo(MockMvcResultHandlers.print())
-            .andExpect(status().isOk());
+                        post("/api/v1/reviews/store")
+                                .content(objectMapper.writeValueAsString(req))
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
@@ -242,7 +242,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
     void getNearRestaurantReview() {
         // given
         ReviewCreateReq req =
-            new ReviewCreateReq(store.getIdx(), 5, "오늘 학식 진짜 미침", List.of(), true);
+                new ReviewCreateReq(store.getIdx(), 5, "오늘 학식 진짜 미침", List.of(), true);
         // when
         var result = reviewService.createReviewByStore(req, user.getIdx());
 
@@ -254,12 +254,12 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
     @Test
     void getNearRestaurantReview_failed() {
         // given
-        ReviewCreateReq req =
-            new ReviewCreateReq(0L, 5, "오늘 학식 진짜 미침", List.of(), true);
+        ReviewCreateReq req = new ReviewCreateReq(0L, 5, "오늘 학식 진짜 미침", List.of(), true);
         // when
-        ApplicationException applicationException = assertThrows(
-            ApplicationException.class,
-            () -> reviewService.createReviewByStore(req, user.getIdx()));
+        ApplicationException applicationException =
+                assertThrows(
+                        ApplicationException.class,
+                        () -> reviewService.createReviewByStore(req, user.getIdx()));
         assertEquals(applicationException.getErrorCode(), ExceptionList.STORE_NOT_FOUND.getCODE());
     }
 }

--- a/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
@@ -228,7 +228,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
         review.addMark(user);
         reviewRepository.saveAndFlush(review);
 
-        String offeredAt = LocalDate.of(2024,1,25).toString();
+        String offeredAt = LocalDate.of(2024, 1, 25).toString();
         // when
         System.out.println("offeredAt = " + offeredAt);
         System.out.println("restaurant.getIdx() = " + restaurant.getIdx());

--- a/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
@@ -5,6 +5,7 @@ import static everymeal.server.meal.MealData.getRestaurant;
 import static everymeal.server.meal.MealData.getRestaurantRegisterReq;
 import static everymeal.server.meal.MealData.getUniversity;
 import static everymeal.server.review.ReviewData.getReviewEntity;
+import static everymeal.server.review.ReviewData.getStoreEntity;
 import static everymeal.server.review.ReviewData.getUserEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,6 +23,8 @@ import everymeal.server.review.entity.Review;
 import everymeal.server.review.entity.ReviewMark;
 import everymeal.server.review.repository.ReviewMarkRepository;
 import everymeal.server.review.repository.ReviewRepository;
+import everymeal.server.store.entity.Store;
+import everymeal.server.store.repository.StoreRepository;
 import everymeal.server.university.entity.University;
 import everymeal.server.university.repository.UniversityRepository;
 import everymeal.server.user.entity.User;
@@ -44,6 +47,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
     @Autowired private RestaurantRepository restaurantRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private ReviewMarkRepository reviewMarkRepository;
+    @Autowired private StoreRepository storeRepository;
 
     /**
      * ============================================================================================
@@ -53,7 +57,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
     private University university;
 
     private Meal meal;
-
+    private Store store;
     private Restaurant restaurant;
     private User user;
     private Review review;
@@ -66,6 +70,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
         meal = mealRepository.save(getMealEntity(restaurant));
         user = userRepository.save(getUserEntity(university));
         review = reviewRepository.save(getReviewEntity(restaurant, user));
+        store = storeRepository.save(getStoreEntity(university));
     }
 
     @AfterEach
@@ -73,6 +78,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
         reviewMarkRepository.deleteAllInBatch();
         reviewRepository.deleteAllInBatch();
         mealRepository.deleteAllInBatch();
+        storeRepository.deleteAllInBatch();
         restaurantRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
         universityRepository.deleteAllInBatch();
@@ -229,5 +235,31 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
         var result = reviewService.getTodayReview(restaurant.getIdx(), offeredAt);
         // then
         assertEquals(result.content(), review.getContent());
+    }
+
+    @DisplayName("주변 식당 리뷰 생성")
+    @Test
+    void getNearRestaurantReview() {
+        // given
+        ReviewCreateReq req =
+            new ReviewCreateReq(store.getIdx(), 5, "오늘 학식 진짜 미침", List.of(), true);
+        // when
+        var result = reviewService.createReviewByStore(req, user.getIdx());
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @DisplayName("없는 식당 리뷰 생성 - 실패")
+    @Test
+    void getNearRestaurantReview_failed() {
+        // given
+        ReviewCreateReq req =
+            new ReviewCreateReq(0L, 5, "오늘 학식 진짜 미침", List.of(), true);
+        // when
+        ApplicationException applicationException = assertThrows(
+            ApplicationException.class,
+            () -> reviewService.createReviewByStore(req, user.getIdx()));
+        assertEquals(applicationException.getErrorCode(), ExceptionList.STORE_NOT_FOUND.getCODE());
     }
 }

--- a/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
@@ -228,7 +228,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
         review.addMark(user);
         reviewRepository.saveAndFlush(review);
 
-        String offeredAt = LocalDate.of(2024, 1, 25).toString();
+        String offeredAt = LocalDate.now().toString();
         // when
         System.out.println("offeredAt = " + offeredAt);
         System.out.println("restaurant.getIdx() = " + restaurant.getIdx());

--- a/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/everymeal/server/review/service/ReviewServiceImplTest.java
@@ -228,7 +228,7 @@ class ReviewServiceImplTest extends IntegrationTestSupport {
         review.addMark(user);
         reviewRepository.saveAndFlush(review);
 
-        String offeredAt = LocalDate.now().toString();
+        String offeredAt = LocalDate.of(2024,1,25).toString();
         // when
         System.out.println("offeredAt = " + offeredAt);
         System.out.println("restaurant.getIdx() = " + restaurant.getIdx());


### PR DESCRIPTION
## 작업 내용
이 머지 리퀘스트에서는 새로운 기능으로 사용자가 주변 식당에 대한 리뷰를 생성할 수 있도록 하는 작업을 수행했습니다. 
주요 변경사항은 다음과 같습니다

ReviewController에 createReviewByStore 메서드 추가
ReviewCreateReq DTO 클래스에 새로운 필드 추가
ReviewService 인터페이스 및 구현체에 createReviewByStore 메서드 추가
Store 엔티티에 addGrade 메서드 추가
MyBatis XML 매퍼 파일에 새로운 쿼리 추가
테스트 코드 작성 및 실행

## 관련 이슈
#83

## 작업 확인 방법
새로운 API를 확인하려면 아래의 방법을 사용하세요:

createReviewByStore API에 적절한 요청을 전송하여 리뷰를 생성합니다.
생성된 리뷰는 해당 식당의 평점에 반영되어야 합니다.
