### PR TITLE
feat(#92): 이미지 삭제/조회 api 개발 및 리뷰 수정 로직 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sonar {
 		property 'sonar.language', 'java'
 		property 'sonar.sourceEncoding', 'UTF-8'
 		property("sonar.test.inclusions", "**/*Test.java")
-		property "sonar.exclusions", "**/test/**, **/*Application*.java, **/dto/**, **/entity/**, **/*Exception*.java, **/*RepositoryImpl.java, **/global/**, **/resources/**, **/*Dao*.java, **/dev/**, **/admin/**"
+		property "sonar.exclusions", "**/test/**, **/*Application*.java, **/dto/**, **/entity/**, **/*Exception*.java, **/*RepositoryImpl.java, **/global/**, **/resources/**, **/*Dao*.java, **/dev/**, **/admin/**, **/Image*.java"
 		property "sonar.java.coveragePlugin", "jacoco"
 		property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
 	}
@@ -128,6 +128,7 @@ jacocoTestReport {
 					"**/*Dao*",
 					"**/dev/**",
 					"**/admin/**",
+					"**/Image*"
 			])
 		}))
 	}
@@ -164,6 +165,7 @@ jacocoTestCoverageVerification {
 					"**/*Dao*",
 					"**/dev/**",
 					"**/admin/**",
+					"**/Image*"
 			])
 		}))
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sonar {
 		property 'sonar.language', 'java'
 		property 'sonar.sourceEncoding', 'UTF-8'
 		property("sonar.test.inclusions", "**/*Test.java")
-		property "sonar.exclusions", "**/test/**, **/*Application*.java, **/dto/**, **/entity/**, **/*Exception*.java, **/*RepositoryImpl.java, **/global/**, **/resources/**, **/*Dao*.java, **/dev/**"
+		property "sonar.exclusions", "**/test/**, **/*Application*.java, **/dto/**, **/entity/**, **/*Exception*.java, **/*RepositoryImpl.java, **/global/**, **/resources/**, **/*Dao*.java, **/dev/**, **/admin/**"
 		property "sonar.java.coveragePlugin", "jacoco"
 		property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
 	}
@@ -127,6 +127,7 @@ jacocoTestReport {
 					"**/global/*",
 					"**/*Dao*",
 					"**/dev/**",
+					"**/admin/**",
 			])
 		}))
 	}
@@ -162,6 +163,7 @@ jacocoTestCoverageVerification {
 					"**/global/*",
 					"**/*Dao*",
 					"**/dev/**",
+					"**/admin/**",
 			])
 		}))
 	}

--- a/src/main/java/everymeal/server/admin/controller/AdminController.java
+++ b/src/main/java/everymeal/server/admin/controller/AdminController.java
@@ -1,0 +1,33 @@
+package everymeal.server.admin.controller;
+
+
+import everymeal.server.admin.dto.AdminUserDto.DefaultProfileImageRes;
+import everymeal.server.admin.service.AdminUserService;
+import everymeal.server.global.dto.response.ApplicationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@RequiredArgsConstructor
+@Tag(name = "Admin API", description = "어드민에서 관리되는 데이터 관련 API입니다.")
+public class AdminController {
+
+    private final AdminUserService adminUserService;
+
+    @Operation(
+            summary = "유저의 기본 프로필 이미지 정보를 반환합니다.",
+            description =
+                    "유저의 기본 프로필 이미지 정보를 반환합니다. <br/>"
+                            + "피그마에 노출되는 순서대로 반환합니다. <br/>"
+                            + "기본 이미지를 선택 시, imgUrl에 imageKey를 넣어주세요. <br/>")
+    @GetMapping("/default-profile-images")
+    public ApplicationResponse<List<DefaultProfileImageRes>> getDefaultProfileImages() {
+        return ApplicationResponse.ok(adminUserService.getDefaultProfileImages());
+    }
+}

--- a/src/main/java/everymeal/server/admin/dto/AdminUserDto.java
+++ b/src/main/java/everymeal/server/admin/dto/AdminUserDto.java
@@ -1,0 +1,22 @@
+package everymeal.server.admin.dto;
+
+import static everymeal.server.global.util.aws.S3Util.getImgUrl;
+
+import everymeal.server.admin.entity.UserDefaultProfileImage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class AdminUserDto {
+
+    @Schema(description = "어드민에서 관리되는 유저의 기본 프로필 이미지 정보를 담은 응답 DTO입니다.")
+    public record DefaultProfileImageRes(
+            @Schema(description = "유저의 기본 프로필 이미지의 idx입니다.") Long idx,
+            @Schema(description = "유저의 기본 프로필 이미지의 URL입니다.") String profileImageUrl,
+            @Schema(description = "유저의 기본 프로필 이미지의 imageKey입니다.") String imageKey) {
+        public static DefaultProfileImageRes of(UserDefaultProfileImage entity) {
+            return new DefaultProfileImageRes(
+                    entity.getIdx(),
+                    getImgUrl(entity.getProfileImgUrl()),
+                    entity.getProfileImgUrl());
+        }
+    }
+}

--- a/src/main/java/everymeal/server/admin/entity/UserDefaultProfileImage.java
+++ b/src/main/java/everymeal/server/admin/entity/UserDefaultProfileImage.java
@@ -1,0 +1,29 @@
+package everymeal.server.admin.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Getter
+@Table(catalog = "admin", name = "user_default_profile_image")
+@Entity
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class UserDefaultProfileImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    private String profileImgUrl;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/everymeal/server/admin/repository/UserDefaultProfileImageRepository.java
+++ b/src/main/java/everymeal/server/admin/repository/UserDefaultProfileImageRepository.java
@@ -1,0 +1,8 @@
+package everymeal.server.admin.repository;
+
+
+import everymeal.server.admin.entity.UserDefaultProfileImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDefaultProfileImageRepository
+        extends JpaRepository<UserDefaultProfileImage, Long> {}

--- a/src/main/java/everymeal/server/admin/service/AdminUserService.java
+++ b/src/main/java/everymeal/server/admin/service/AdminUserService.java
@@ -1,0 +1,23 @@
+package everymeal.server.admin.service;
+
+
+import everymeal.server.admin.dto.AdminUserDto.DefaultProfileImageRes;
+import everymeal.server.admin.repository.UserDefaultProfileImageRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+
+    private final UserDefaultProfileImageRepository userDefaultProfileImageRepository;
+
+    public List<DefaultProfileImageRes> getDefaultProfileImages() {
+        return userDefaultProfileImageRepository.findAll().stream()
+                .map(DefaultProfileImageRes::of)
+                .toList();
+    }
+}

--- a/src/main/java/everymeal/server/global/util/aws/S3Util.java
+++ b/src/main/java/everymeal/server/global/util/aws/S3Util.java
@@ -7,16 +7,19 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import java.io.File;
 import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class S3Util {
 
     public static AmazonS3 amazonS3;
@@ -55,5 +58,15 @@ public class S3Util {
     public static String getImgUrl(String fileName) {
         URL url = amazonS3.getUrl(bucket, runningName + File.separator + fileName);
         return url.toString();
+    }
+
+    public void deleteImage(String fileUrl) {
+        try {
+            String fileKey = "dev/" + fileUrl;
+            amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileKey));
+        } catch (Exception e) {
+            e.printStackTrace();
+            log.error("S3 이미지 삭제 실패 fileUrl: {}", fileUrl);
+        }
     }
 }

--- a/src/main/java/everymeal/server/global/util/aws/controller/S3Controller.java
+++ b/src/main/java/everymeal/server/global/util/aws/controller/S3Controller.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -49,5 +50,24 @@ public class S3Controller {
         URL test = s3Util.getPresignedUrl(fileName);
         return ApplicationResponse.ok(
                 S3GetResignedUrlRes.builder().imageKey(fileName).url(test.toString()).build());
+    }
+
+    @Operation(
+            summary = "S3 이미지 삭제",
+            description =
+                    """
+        S3에 저장된 이미지를 삭제합니다.
+        언제 사용하는 API인가요?
+        1. 리뷰 작성 중 이미지를 업로드하고, 리뷰 작성을 취소할 때
+        2. 리뷰 수정 중 이미지를 업로드하고, 리뷰 수정을 취소할 때
+        3. 리뷰 삭제 시 이미지를 삭제할 때
+        4. 이미지를 잘못 업로드 했을 때
+        5. 유저 프로필 이미지를 변경할 때 ( 기본 이미지 제외 )
+""")
+    @DeleteMapping("/image")
+    public ApplicationResponse<Void> deleteImage(
+            @RequestParam(value = "fileName") String fileName) {
+        s3Util.deleteImage(fileName);
+        return ApplicationResponse.ok();
     }
 }

--- a/src/main/java/everymeal/server/review/dto/request/ReviewCreateReq.java
+++ b/src/main/java/everymeal/server/review/dto/request/ReviewCreateReq.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record ReviewCreateReq(
@@ -14,7 +15,7 @@ public record ReviewCreateReq(
                         description =
                                 "학식에 대한 리뷰 평가 점수를 정수형 최소 1 ~ 최대 5점까지로 입력해주세요. 사진 리뷰인 경우 0으로 보내주세요.",
                         defaultValue = "5")
-                @Nullable
+                @NotNull
                 Integer grade,
         @Schema(
                         description = "학식에 대한 리뷰 내용을 1글자 이상 입력해주세요. 사진 리뷰인 경우 null로 보내주세요.",

--- a/src/main/java/everymeal/server/review/entity/Image.java
+++ b/src/main/java/everymeal/server/review/entity/Image.java
@@ -35,4 +35,8 @@ public class Image extends BaseEntity {
         this.isDeleted = false;
         this.review = review;
     }
+
+    public void deleteImage() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/everymeal/server/review/entity/Review.java
+++ b/src/main/java/everymeal/server/review/entity/Review.java
@@ -90,9 +90,8 @@ public class Review extends BaseEntity {
     public void updateEntity(String content, int grade, List<Image> images, Boolean todayReview) {
         this.content = content;
         this.grade = grade;
-        if (images != null) {
-            this.images.clear();
-        }
+        // 이미지 연관 리스트 지우고 새로운 이미지 리스트로 교체
+        this.images.clear();
         this.images = images;
         this.isTodayReview = todayReview;
     }

--- a/src/main/java/everymeal/server/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/everymeal/server/review/repository/ReviewRepositoryImpl.java
@@ -34,10 +34,16 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 jpaQueryFactory
                         .select(review)
                         .from(review)
-                        .leftJoin(review.images, image)
-                        .leftJoin(review.reviewMarks, reviewMark)
-                        .leftJoin(review.restaurant)
-                        .on(restaurant.idx.eq(queryParam.restaurantIdx()))
+                        .leftJoin(image)
+                        .on(review.idx.eq(image.review.idx))
+                        .leftJoin(reviewMark)
+                        .on(review.idx.eq(reviewMark.review.idx))
+                        .innerJoin(restaurant)
+                        .on(
+                                review.restaurant
+                                        .idx
+                                        .eq(restaurant.idx)
+                                        .and(restaurant.idx.eq(queryParam.restaurantIdx())))
                         .where(
                                 gtReviewIdx(queryParam.cursorIdx()),
                                 isDeleted(),
@@ -51,10 +57,19 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                                 jpaQueryFactory
                                         .select(review.idx.count())
                                         .from(review)
-                                        .leftJoin(review.images, image)
-                                        .leftJoin(review.reviewMarks, reviewMark)
-                                        .leftJoin(review.restaurant)
-                                        .on(restaurant.idx.eq(queryParam.restaurantIdx()))
+                                        .leftJoin(image)
+                                        .on(review.idx.eq(image.review.idx))
+                                        .leftJoin(reviewMark)
+                                        .on(review.idx.eq(reviewMark.review.idx))
+                                        .innerJoin(restaurant)
+                                        .on(
+                                                review.restaurant
+                                                        .idx
+                                                        .eq(restaurant.idx)
+                                                        .and(
+                                                                restaurant.idx.eq(
+                                                                        queryParam
+                                                                                .restaurantIdx())))
                                         .where(isDeleted(), eqToday(queryParam.filter()))
                                         .fetchOne())
                         .intValue();

--- a/src/main/java/everymeal/server/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/everymeal/server/review/repository/ReviewRepositoryImpl.java
@@ -35,7 +35,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                         .select(review)
                         .from(review)
                         .leftJoin(image)
-                        .on(review.idx.eq(image.review.idx))
+                        .on(review.idx.eq(image.review.idx).and(image.isDeleted.eq(Boolean.FALSE)))
                         .leftJoin(reviewMark)
                         .on(review.idx.eq(reviewMark.review.idx))
                         .innerJoin(restaurant)
@@ -58,7 +58,10 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                                         .select(review.idx.count())
                                         .from(review)
                                         .leftJoin(image)
-                                        .on(review.idx.eq(image.review.idx))
+                                        .on(
+                                                review.idx
+                                                        .eq(image.review.idx)
+                                                        .and(image.isDeleted.eq(Boolean.FALSE)))
                                         .leftJoin(reviewMark)
                                         .on(review.idx.eq(reviewMark.review.idx))
                                         .innerJoin(restaurant)

--- a/src/main/java/everymeal/server/review/service/ImageCommServiceImpl.java
+++ b/src/main/java/everymeal/server/review/service/ImageCommServiceImpl.java
@@ -1,0 +1,20 @@
+package everymeal.server.review.service;
+
+
+import everymeal.server.review.entity.Image;
+import everymeal.server.review.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ImageCommServiceImpl {
+
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public void deleteImage(Image alreadyImg) {
+        imageRepository.delete(alreadyImg);
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 유저 프로필 이미지 관련
1. 피그마에 정의되어 있는 유저의 기본 프로필 사진을 S3 /user 폴더 아래 적재했습니다.
2. 적재된 이미지의 imageKey를 갖는 별도의 테이블을 생성했습니다. ( 이 테이블은 admin 스키마에 존재합니다. )
3. 기본 이미지로 사용되는 이미지 리스트를 조회하는 api를 새로 개발했습니다.

- 리뷰 수정 시, 이미지 관련
1. 리뷰 수정 시, 변경되는 이미지에 대해 s3에서 삭제하는 로직을 추가했습니다.

- 리뷰 삭제 시, 이미지 관련
1. 리뷰 삭제 시, 연관된 이미지들을 삭제 상태로 변경하는 로직을 추가했습니다.

- 클라이언트가 이미지를 잘못 업로드 했을 경우
1. s3에 적재된 이미지를 삭제할 수 있는 api를 새로 개발했습니다.

## 관련 이슈

#92 

## 작업 확인 방법

swagger-ui를 통해 확인 가능합니다.

## 추가 정보 (선택 사항)

admin 스키마는 개발/운영 환경에 종속되지 않고 독립적으로 관리될 수 있도록 하기 위해 별도로 생성하였습니다.