### PR TITLE
refactor : store review like count 추가

### DIFF
--- a/src/main/java/everymeal/server/review/entity/Review.java
+++ b/src/main/java/everymeal/server/review/entity/Review.java
@@ -107,12 +107,20 @@ public class Review extends BaseEntity {
     public void addMark(User user) {
         ReviewMark reviewMark = ReviewMark.builder().review(this).user(user).build();
         this.reviewMarks.add(reviewMark);
-        this.restaurant.getGradeStatistics().addRecommendedCount();
+        if (this.restaurant == null) {
+            this.store.getGradeStatistics().addRecommendedCount();
+        } else {
+            this.restaurant.getGradeStatistics().addRecommendedCount();
+        }
     }
 
     public void removeMark(User user) {
         this.reviewMarks.removeIf(mark -> mark.getUser().getIdx().equals(user.getIdx()));
-        this.restaurant.getGradeStatistics().removeRecommendedCount();
+        if (this.restaurant == null) {
+            this.store.getGradeStatistics().addRecommendedCount();
+        } else {
+            this.restaurant.getGradeStatistics().addRecommendedCount();
+        }
     }
 
     public boolean isLike(Long userIdx) {

--- a/src/main/java/everymeal/server/store/controller/dto/response/StoreGetReviewRes.java
+++ b/src/main/java/everymeal/server/store/controller/dto/response/StoreGetReviewRes.java
@@ -15,7 +15,8 @@ public record StoreGetReviewRes(
         String nickName,
         String profileImageUrl,
         Integer recommendedCount,
-        List<String> images) {
+        List<String> images,
+        Long likeCount) {
 
     public static List<StoreGetReviewRes> of(List<Map<String, Object>> storeReview) {
         return storeReview.stream()
@@ -34,7 +35,8 @@ public record StoreGetReviewRes(
                                     (String) review.get("nickName"),
                                     S3Util.getImgUrl((String) review.get("profileImageUrl")),
                                     (Integer) review.get("recommendedCount"),
-                                    images);
+                                    images,
+                                    (Long) review.get("likeCount"));
                         })
                 .toList();
     }

--- a/src/main/resources/mybatis/mappers/StoreMapper.xml
+++ b/src/main/resources/mybatis/mappers/StoreMapper.xml
@@ -385,7 +385,8 @@
       u.nickname as 'nickname',
       u.profile_img_url as 'profileImageUrl',
       s.recommended_count as 'recommendedCount',
-      GROUP_CONCAT(i.image_url SEPARATOR ',') AS 'images'
+      GROUP_CONCAT(i.image_url SEPARATOR ',') AS 'images',
+      count(distinct rm.review_idx) as 'likeCount'
     FROM
       reviews r
         JOIN
@@ -394,6 +395,8 @@
       images i ON r.idx = i.review_idx AND i.is_deleted = false
         LEFT JOIN
       store s ON r.store_idx = s.idx AND s.is_deleted = false
+        LEFT JOIN
+      review_marks rm ON r.idx = rm.review_idx
     WHERE
       r.store_idx = #{storeIdx}
         AND r.is_deleted = false


### PR DESCRIPTION
## 작업 내용
Review 엔티티의 addMark 및 removeMark 메서드 수정
restaurant가 null일 때 store의 등급 통계를 업데이트하도록 수정

## 작업 확인 방법
이 코드의 변경 사항은 테스트 케이스를 실행하여 확인할 수 있습니다. 리뷰에 대한 표시를 추가하고 제거하는 경우 해당 식당 또는 가게의 등급 통계가 올바르게 업데이트되는지 확인할 수 있습니다. 특히 restaurant가 null인 경우에도 store의 등급 통계가 올바르게 업데이트되는지 확인해야 합니다.

## 추가 정보 (선택 사항)
이 수정된 코드는 리뷰에 대한 표시(mark)를 추가하거나 제거할 때 등급 통계를 업데이트합니다. 만약 리뷰가 식당(restaurant)에 속한다면 해당 식당의 등급 통계를 업데이트하고, 그렇지 않은 경우에는 가게(store)의 등급 통계를 업데이트합니다.